### PR TITLE
Remove hardcoded credentials from deploy.sh

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ dist/
 .env
 .env.local
 .DS_Store
+deploy.local.sh

--- a/deploy.sh
+++ b/deploy.sh
@@ -57,13 +57,14 @@ fi
 
 # ─── 5. Environment file ──────────────────────
 if [ ! -f "$APP_DIR/.env.local" ]; then
-    echo "==> [5/7] Creating .env.local..."
-    cat > "$APP_DIR/.env.local" << 'ENVEOF'
-MONGODB_URI=mongodb+srv://atharvajaynaik_db_user:Fuy2DMfoScGhOqLx@graciasai.3owqrsn.mongodb.net/
-ENVEOF
-    echo "    Created .env.local"
+    echo "==> [5/7] .env.local not found!"
+    echo "    Create it manually:"
+    echo "    echo 'MONGODB_URI=your_mongodb_uri_here' > $APP_DIR/.env.local"
+    echo ""
+    echo "    Then re-run this script."
+    exit 1
 else
-    echo "==> [5/7] .env.local already exists. Skipping."
+    echo "==> [5/7] .env.local exists. Skipping."
 fi
 
 # ─── 6. Build ─────────────────────────────────


### PR DESCRIPTION
## Summary

- Remove hardcoded MongoDB URI from `deploy.sh` (was exposing credentials in public repo)
- Script now exits with instructions if `.env.local` is missing
- Add `deploy.local.sh` to `.gitignore` for local deploy scripts containing secrets

## Test plan

- [ ] Run `deploy.sh` without `.env.local` — should exit with instructions
- [ ] Run `deploy.sh` with `.env.local` present — should proceed normally