### PR TITLE
Add Clerk auth gate on CTA click

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,6 @@
 import './globals.css';
 import type { Metadata } from 'next';
+import { ClerkProvider } from '@clerk/nextjs';
 
 export const metadata: Metadata = {
   title: 'Gracias AI - App Store Compliance Auditor',
@@ -15,8 +16,10 @@ export default function RootLayout({
   children: React.ReactNode
 }) {
   return (
-    <html lang="en">
-      <body>{children}</body>
-    </html>
+    <ClerkProvider>
+      <html lang="en">
+        <body>{children}</body>
+      </html>
+    </ClerkProvider>
   )
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -11,7 +11,7 @@ import {
 } from 'lucide-react';
 import ReactMarkdown from 'react-markdown';
 import Link from 'next/link';
-// import { UserButton, SignInButton, SignedOut, SignedIn, useAuth, useClerk } from '@clerk/nextjs';
+import { UserButton, SignedOut, SignedIn, useAuth, useClerk } from '@clerk/nextjs';
 
 type AuditPhase = 'idle' | 'uploading' | 'analyzing' | 'complete' | 'error';
 
@@ -141,8 +141,16 @@ export default function AuditPage() {
     return (bytes / (1024 * 1024)).toFixed(1) + ' MB';
   };
 
+  const { isSignedIn } = useAuth();
+  const { openSignIn } = useClerk();
+
   const handleRunAudit = async () => {
     if (!file || !claudeApiKey.trim()) return;
+
+    if (!isSignedIn) {
+      openSignIn();
+      return;
+    }
     setPhase('uploading');
     setReportContent('');
     setErrorMessage('');
@@ -339,6 +347,17 @@ export default function AuditPage() {
               <Github className="w-3.5 h-3.5" />
               <span className="hidden sm:inline">GitHub</span>
             </Link>
+            <SignedOut>
+              <button
+                onClick={() => openSignIn()}
+                className="px-3 py-1.5 rounded-lg bg-gradient-to-r from-primary to-blue-600 text-xs font-bold text-white hover:opacity-90 transition-opacity"
+              >
+                Sign In
+              </button>
+            </SignedOut>
+            <SignedIn>
+              <UserButton />
+            </SignedIn>
           </div>
         </div>
       </header>


### PR DESCRIPTION
## Summary

- Re-enable ClerkProvider in root layout
- CTA "Run Compliance Audit" button now checks auth state — opens Clerk sign-in modal if user is not signed in, proceeds with audit if signed in
- Added Sign In button (logged out) and UserButton (logged in) to the header nav

## Test plan

- [ ] Click "Run Compliance Audit" without signing in — should open Clerk sign-in modal
- [ ] Sign in via Clerk, then click CTA — should start the audit normally
- [ ] Verify UserButton appears in header after sign-in
- [ ] Verify Sign In button appears in header when logged out