### PR TITLE
Add Gracias AI SVG logo pack

### DIFF
--- a/logo/README.md
+++ b/logo/README.md
@@ -1,0 +1,22 @@
+# Gracias AI Logo Pack
+
+Original SVG logo submission for issue #2.
+
+## Files
+
+- `logomark.svg`: icon-only mark for light backgrounds.
+- `logomark-dark.svg`: icon-only mark tuned for dark backgrounds.
+- `wordmark.svg`: icon plus "Gracias AI" wordmark for light backgrounds.
+- `wordmark-dark.svg`: icon plus "Gracias AI" wordmark tuned for dark backgrounds.
+
+## Design Rationale
+
+The mark combines a rounded app tile, a compliance shield, a checkmark, and neural-network nodes. It is meant to signal iOS/app review readiness, security, trust, and AI-assisted analysis without copying Apple-owned marks.
+
+The colors use the requested brand palette:
+
+- Purple: `#a855f7`
+- Blue: `#3b82f6`
+- White: `#ffffff`
+
+All artwork is vector SVG and can be scaled without raster assets.

--- a/logo/logomark-dark.svg
+++ b/logo/logomark-dark.svg
@@ -1,0 +1,29 @@
+<svg width="256" height="256" viewBox="0 0 256 256" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="title desc">
+  <title id="title">Gracias AI logomark for dark backgrounds</title>
+  <desc id="desc">A glowing rounded app tile containing a compliance shield, neural nodes, and an approval check.</desc>
+  <defs>
+    <linearGradient id="tile" x1="48" y1="32" x2="208" y2="224" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#c084fc"/>
+      <stop offset="1" stop-color="#60a5fa"/>
+    </linearGradient>
+    <linearGradient id="shield" x1="88" y1="64" x2="168" y2="188" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#ffffff"/>
+      <stop offset="1" stop-color="#eef2ff"/>
+    </linearGradient>
+    <filter id="glow" x="12" y="8" width="232" height="236" color-interpolation-filters="sRGB" filterUnits="userSpaceOnUse">
+      <feDropShadow dx="0" dy="0" stdDeviation="10" flood-color="#60a5fa" flood-opacity="0.35"/>
+      <feDropShadow dx="0" dy="18" stdDeviation="20" flood-color="#a855f7" flood-opacity="0.18"/>
+    </filter>
+  </defs>
+  <rect x="36" y="28" width="184" height="184" rx="44" fill="url(#tile)" filter="url(#glow)"/>
+  <path d="M128 58L174 76V116C174 150 154.8 178.5 128 190C101.2 178.5 82 150 82 116V76L128 58Z" fill="url(#shield)"/>
+  <path d="M128 58L174 76V116C174 150 154.8 178.5 128 190C101.2 178.5 82 150 82 116V76L128 58Z" stroke="#ffffff" stroke-opacity="0.9" stroke-width="4" stroke-linejoin="round"/>
+  <path d="M101 124L121 144L158 103" stroke="#1d4ed8" stroke-width="11" stroke-linecap="round" stroke-linejoin="round"/>
+  <path d="M98 91H158M98 91L120 112M158 91L136 112M120 112H136M120 112L104 143M136 112L152 143" stroke="#7c3aed" stroke-width="5" stroke-linecap="round" opacity="0.72"/>
+  <circle cx="98" cy="91" r="8" fill="#a855f7"/>
+  <circle cx="158" cy="91" r="8" fill="#3b82f6"/>
+  <circle cx="120" cy="112" r="7" fill="#8b5cf6"/>
+  <circle cx="136" cy="112" r="7" fill="#60a5fa"/>
+  <circle cx="104" cy="143" r="6" fill="#a855f7"/>
+  <circle cx="152" cy="143" r="6" fill="#3b82f6"/>
+</svg>

--- a/logo/logomark.svg
+++ b/logo/logomark.svg
@@ -1,0 +1,28 @@
+<svg width="256" height="256" viewBox="0 0 256 256" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="title desc">
+  <title id="title">Gracias AI logomark</title>
+  <desc id="desc">A rounded app tile containing a compliance shield, neural nodes, and an approval check.</desc>
+  <defs>
+    <linearGradient id="tile" x1="48" y1="32" x2="208" y2="224" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#a855f7"/>
+      <stop offset="1" stop-color="#3b82f6"/>
+    </linearGradient>
+    <linearGradient id="shield" x1="88" y1="64" x2="168" y2="188" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#ffffff"/>
+      <stop offset="1" stop-color="#e0f2fe"/>
+    </linearGradient>
+    <filter id="softShadow" x="24" y="24" width="208" height="216" color-interpolation-filters="sRGB" filterUnits="userSpaceOnUse">
+      <feDropShadow dx="0" dy="14" stdDeviation="16" flood-color="#1e1b4b" flood-opacity="0.22"/>
+    </filter>
+  </defs>
+  <rect x="36" y="28" width="184" height="184" rx="44" fill="url(#tile)" filter="url(#softShadow)"/>
+  <path d="M128 58L174 76V116C174 150 154.8 178.5 128 190C101.2 178.5 82 150 82 116V76L128 58Z" fill="url(#shield)"/>
+  <path d="M128 58L174 76V116C174 150 154.8 178.5 128 190C101.2 178.5 82 150 82 116V76L128 58Z" stroke="#ffffff" stroke-opacity="0.8" stroke-width="4" stroke-linejoin="round"/>
+  <path d="M101 124L121 144L158 103" stroke="#2563eb" stroke-width="11" stroke-linecap="round" stroke-linejoin="round"/>
+  <path d="M98 91H158M98 91L120 112M158 91L136 112M120 112H136M120 112L104 143M136 112L152 143" stroke="#7c3aed" stroke-width="5" stroke-linecap="round" opacity="0.7"/>
+  <circle cx="98" cy="91" r="8" fill="#a855f7"/>
+  <circle cx="158" cy="91" r="8" fill="#3b82f6"/>
+  <circle cx="120" cy="112" r="7" fill="#8b5cf6"/>
+  <circle cx="136" cy="112" r="7" fill="#60a5fa"/>
+  <circle cx="104" cy="143" r="6" fill="#a855f7"/>
+  <circle cx="152" cy="143" r="6" fill="#3b82f6"/>
+</svg>

--- a/logo/wordmark-dark.svg
+++ b/logo/wordmark-dark.svg
@@ -1,0 +1,31 @@
+<svg width="720" height="180" viewBox="0 0 720 180" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="title desc">
+  <title id="title">Gracias AI wordmark for dark backgrounds</title>
+  <desc id="desc">Gracias AI wordmark with a compliance shield and neural app tile, tuned for dark backgrounds.</desc>
+  <defs>
+    <linearGradient id="tile" x1="32" y1="24" x2="148" y2="148" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#c084fc"/>
+      <stop offset="1" stop-color="#60a5fa"/>
+    </linearGradient>
+    <linearGradient id="shield" x1="62" y1="46" x2="118" y2="132" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#ffffff"/>
+      <stop offset="1" stop-color="#eef2ff"/>
+    </linearGradient>
+    <filter id="glow" x="6" y="4" width="172" height="172" color-interpolation-filters="sRGB" filterUnits="userSpaceOnUse">
+      <feDropShadow dx="0" dy="0" stdDeviation="7" flood-color="#60a5fa" flood-opacity="0.3"/>
+      <feDropShadow dx="0" dy="14" stdDeviation="14" flood-color="#a855f7" flood-opacity="0.16"/>
+    </filter>
+  </defs>
+  <rect x="24" y="22" width="136" height="136" rx="34" fill="url(#tile)" filter="url(#glow)"/>
+  <path d="M92 44L126 57V87C126 112 111.8 133 92 141C72.2 133 58 112 58 87V57L92 44Z" fill="url(#shield)" stroke="#ffffff" stroke-opacity="0.9" stroke-width="3" stroke-linejoin="round"/>
+  <path d="M72 92L87 107L113 77" stroke="#1d4ed8" stroke-width="8" stroke-linecap="round" stroke-linejoin="round"/>
+  <path d="M70 69H114M70 69L86 84M114 69L98 84M86 84H98M86 84L74 108M98 84L110 108" stroke="#7c3aed" stroke-width="3.5" stroke-linecap="round" opacity="0.74"/>
+  <circle cx="70" cy="69" r="5.5" fill="#a855f7"/>
+  <circle cx="114" cy="69" r="5.5" fill="#3b82f6"/>
+  <circle cx="86" cy="84" r="5" fill="#8b5cf6"/>
+  <circle cx="98" cy="84" r="5" fill="#60a5fa"/>
+  <circle cx="74" cy="108" r="4.5" fill="#a855f7"/>
+  <circle cx="110" cy="108" r="4.5" fill="#3b82f6"/>
+  <text x="190" y="94" fill="#f8fafc" font-family="Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="56" font-weight="760" letter-spacing="0">Gracias</text>
+  <text x="417" y="94" fill="#93c5fd" font-family="Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="56" font-weight="760" letter-spacing="0">AI</text>
+  <text x="192" y="125" fill="#cbd5e1" font-family="Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="16" font-weight="650" letter-spacing="2.8">APP STORE COMPLIANCE AUDITOR</text>
+</svg>

--- a/logo/wordmark.svg
+++ b/logo/wordmark.svg
@@ -1,0 +1,27 @@
+<svg width="720" height="180" viewBox="0 0 720 180" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="title desc">
+  <title id="title">Gracias AI wordmark</title>
+  <desc id="desc">Gracias AI wordmark with a compliance shield and neural app tile.</desc>
+  <defs>
+    <linearGradient id="tile" x1="32" y1="24" x2="148" y2="148" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#a855f7"/>
+      <stop offset="1" stop-color="#3b82f6"/>
+    </linearGradient>
+    <linearGradient id="shield" x1="62" y1="46" x2="118" y2="132" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#ffffff"/>
+      <stop offset="1" stop-color="#e0f2fe"/>
+    </linearGradient>
+  </defs>
+  <rect x="24" y="22" width="136" height="136" rx="34" fill="url(#tile)"/>
+  <path d="M92 44L126 57V87C126 112 111.8 133 92 141C72.2 133 58 112 58 87V57L92 44Z" fill="url(#shield)" stroke="#ffffff" stroke-opacity="0.85" stroke-width="3" stroke-linejoin="round"/>
+  <path d="M72 92L87 107L113 77" stroke="#2563eb" stroke-width="8" stroke-linecap="round" stroke-linejoin="round"/>
+  <path d="M70 69H114M70 69L86 84M114 69L98 84M86 84H98M86 84L74 108M98 84L110 108" stroke="#7c3aed" stroke-width="3.5" stroke-linecap="round" opacity="0.7"/>
+  <circle cx="70" cy="69" r="5.5" fill="#a855f7"/>
+  <circle cx="114" cy="69" r="5.5" fill="#3b82f6"/>
+  <circle cx="86" cy="84" r="5" fill="#8b5cf6"/>
+  <circle cx="98" cy="84" r="5" fill="#60a5fa"/>
+  <circle cx="74" cy="108" r="4.5" fill="#a855f7"/>
+  <circle cx="110" cy="108" r="4.5" fill="#3b82f6"/>
+  <text x="190" y="94" fill="#111827" font-family="Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="56" font-weight="760" letter-spacing="0">Gracias</text>
+  <text x="417" y="94" fill="#2563eb" font-family="Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="56" font-weight="760" letter-spacing="0">AI</text>
+  <text x="192" y="125" fill="#64748b" font-family="Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="16" font-weight="650" letter-spacing="2.8">APP STORE COMPLIANCE AUDITOR</text>
+</svg>


### PR DESCRIPTION
Closes #2.

## Summary
- Adds an original Gracias AI logo pack under `logo/`
- Includes logomark and wordmark variants
- Includes light-background and dark-background SVG variants
- Uses the requested purple/blue/white palette
- Represents AI, App Store review, security, and trust through a rounded app tile, neural nodes, shield, and checkmark

## Files
- `logo/logomark.svg`
- `logo/logomark-dark.svg`
- `logo/wordmark.svg`
- `logo/wordmark-dark.svg`
- `logo/README.md`

## Verification
- Parsed all SVG files as valid XML
- Ran `git diff --check`
- Rendered `wordmark.svg` with headless Chrome for a visual smoke check