### PR TITLE
feat: add binary compare CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ AI-powered iOS App Store compliance auditor. Upload your `.ipa` file and get a c
 - **Model Selection** — Choose specific models per provider (Claude Sonnet 4, GPT-4o, Gemini 2.5 Flash, etc.)
 - **Real-Time Streaming** — Watch your audit report generate live as the AI analyzes your code
 - **Export Reports** — Download as Markdown or PDF
+- **Binary Compare CLI** — Compare two app artifacts or extracted directories and emit a diff knowledge graph
 - **Zero-Trust Security** — Files processed in ephemeral temp storage and deleted immediately. API keys stay in your browser, never on our servers
 - **100% Open Source** — Fully auditable codebase
 
@@ -84,6 +85,17 @@ npm start
 ## Client Wrappers / SDKs
 
 ipaShip provides ready-to-use boilerplate SDKs and wrappers for various ecosystems and languages. You can find them in the `wrappers/` directory. Each wrapper is skeletoned to pragmatically audit your `.ipa` files directly from your CI/CD pipelines, backend backend, or build environments!
+
+## Binary Compare CLI
+
+Compare two app versions as files, such as `.ipa` archives, or compare two extracted app directories:
+
+```bash
+npx ipaship compare --file ./App-1.0.0.ipa --file ./App-1.0.1.ipa
+npx ipaship compare --file ./App-1.0.0 --file ./App-1.0.1 --json
+```
+
+The text output summarizes whether artifacts match, SHA-256 fingerprints, byte ranges for binary file differences, and changed files for directory comparisons. The `--json` form includes a simple knowledge graph with artifact, byte-range, or file-change nodes for downstream tooling.
 
 ### Commands to Run Wrappers
 

--- a/package.json
+++ b/package.json
@@ -2,6 +2,9 @@
   "name": "ipaship",
   "version": "1.0.0",
   "main": "index.js",
+  "bin": {
+    "ipaship": "scripts/ipaship-cli.js"
+  },
   "engines": {
     "node": ">=20"
   },

--- a/scripts/ipaship-cli.js
+++ b/scripts/ipaship-cli.js
@@ -1,0 +1,107 @@
+#!/usr/bin/env node
+
+const { pathToFileURL } = require('node:url');
+
+function printUsage() {
+  console.error(`Usage:
+  ipaship compare --file <left> --file <right> [--json]
+  ipaship --ipaship compare --file <left> --file <right> [--json]
+
+Options:
+  --file <path>       File or directory to compare. Provide exactly two.
+  --max-ranges <n>    Maximum byte ranges to include for file diffs. Default: 200.
+  --json              Print full JSON, including the knowledge graph.
+`);
+}
+
+function parseArgs(argv) {
+  const args = argv.filter(arg => arg !== '--ipaship');
+  const command = args[0];
+  const files = [];
+  let json = false;
+  let maxRanges;
+
+  for (let index = 1; index < args.length; index += 1) {
+    const arg = args[index];
+    if (arg === '--file') {
+      const value = args[index + 1];
+      if (!value || value.startsWith('--')) {
+        throw new Error('--file requires a path value.');
+      }
+      files.push(value);
+      index += 1;
+    } else if (arg === '--json') {
+      json = true;
+    } else if (arg === '--max-ranges') {
+      const value = Number(args[index + 1]);
+      if (!Number.isInteger(value) || value < 1) {
+        throw new Error('--max-ranges requires a positive integer.');
+      }
+      maxRanges = value;
+      index += 1;
+    } else {
+      throw new Error(`Unknown argument: ${arg}`);
+    }
+  }
+
+  if (command !== 'compare') {
+    throw new Error('Expected command: compare');
+  }
+  if (files.length !== 2) {
+    throw new Error('Compare requires exactly two --file arguments.');
+  }
+
+  return { files, json, maxRanges };
+}
+
+function printTextSummary(result) {
+  console.log(`ipaShip compare: ${result.equal ? 'MATCH' : 'DIFFERENT'}`);
+  console.log(`Kind: ${result.kind}`);
+  console.log(`Left: ${result.left.path}`);
+  console.log(`Right: ${result.right.path}`);
+
+  if (result.kind === 'file') {
+    console.log(`Left SHA-256: ${result.left.sha256}`);
+    console.log(`Right SHA-256: ${result.right.sha256}`);
+    console.log(`Differing bytes: ${result.differingBytes}`);
+    if (result.differenceRanges.length > 0) {
+      console.log('Difference ranges:');
+      for (const range of result.differenceRanges) {
+        console.log(`  - ${range.start}-${range.end} (${range.length} bytes)`);
+      }
+      if (result.truncatedRanges) {
+        console.log('  - Additional ranges omitted. Increase --max-ranges to include more.');
+      }
+    }
+  } else {
+    console.log(`Changed files: ${result.changes.length}`);
+    for (const change of result.changes) {
+      console.log(`  - ${change.type}: ${change.path}`);
+    }
+  }
+
+  console.log(`Knowledge graph: ${result.knowledgeGraph.nodes.length} nodes, ${result.knowledgeGraph.edges.length} edges`);
+}
+
+async function main() {
+  try {
+    const { files, json, maxRanges } = parseArgs(process.argv.slice(2));
+    const moduleUrl = pathToFileURL(require.resolve('../src/utils/binary-compare.mjs')).href;
+    const { compareArtifacts } = await import(moduleUrl);
+    const result = await compareArtifacts(files[0], files[1], { maxRanges });
+
+    if (json) {
+      console.log(JSON.stringify(result, null, 2));
+    } else {
+      printTextSummary(result);
+    }
+
+    process.exitCode = result.equal ? 0 : 1;
+  } catch (error) {
+    console.error(`ipaship: ${error.message}`);
+    printUsage();
+    process.exitCode = 2;
+  }
+}
+
+main();

--- a/src/utils/binary-compare.mjs
+++ b/src/utils/binary-compare.mjs
@@ -1,0 +1,247 @@
+import { createHash } from 'node:crypto';
+import { createReadStream, promises as fs } from 'node:fs';
+import path from 'node:path';
+
+const DEFAULT_CHUNK_SIZE = 64 * 1024;
+const DEFAULT_MAX_RANGES = 200;
+
+function normalizeRelativePath(filePath) {
+  return filePath.split(path.sep).join('/');
+}
+
+async function statPath(filePath) {
+  try {
+    return await fs.stat(filePath);
+  } catch (error) {
+    throw new Error(`Unable to read ${filePath}: ${error.message}`);
+  }
+}
+
+async function hashFile(filePath) {
+  const hash = createHash('sha256');
+  await new Promise((resolve, reject) => {
+    createReadStream(filePath)
+      .on('data', chunk => hash.update(chunk))
+      .on('error', reject)
+      .on('end', resolve);
+  });
+  return hash.digest('hex');
+}
+
+function pushRange(ranges, start, end, maxRanges) {
+  if (start === null || end < start) return;
+
+  const previous = ranges[ranges.length - 1];
+  if (previous && previous.end + 1 === start) {
+    previous.end = end;
+    previous.length = previous.end - previous.start + 1;
+    return;
+  }
+
+  if (ranges.length < maxRanges) {
+    ranges.push({ start, end, length: end - start + 1 });
+  }
+}
+
+async function readChunk(handle, buffer, position) {
+  const result = await handle.read(buffer, 0, buffer.length, position);
+  return result.bytesRead;
+}
+
+async function compareFileBytes(leftPath, rightPath, options = {}) {
+  const chunkSize = options.chunkSize || DEFAULT_CHUNK_SIZE;
+  const maxRanges = options.maxRanges || DEFAULT_MAX_RANGES;
+  const leftStat = await statPath(leftPath);
+  const rightStat = await statPath(rightPath);
+  const comparedLength = Math.min(leftStat.size, rightStat.size);
+  const ranges = [];
+  let differingBytes = 0;
+  let currentStart = null;
+  let currentEnd = null;
+  let leftHandle;
+  let rightHandle;
+
+  try {
+    leftHandle = await fs.open(leftPath, 'r');
+    rightHandle = await fs.open(rightPath, 'r');
+
+    const leftBuffer = Buffer.allocUnsafe(chunkSize);
+    const rightBuffer = Buffer.allocUnsafe(chunkSize);
+    let position = 0;
+
+    while (position < comparedLength) {
+      const bytesToRead = Math.min(chunkSize, comparedLength - position);
+      const leftView = leftBuffer.subarray(0, bytesToRead);
+      const rightView = rightBuffer.subarray(0, bytesToRead);
+      const leftRead = await readChunk(leftHandle, leftView, position);
+      const rightRead = await readChunk(rightHandle, rightView, position);
+      const readLength = Math.min(leftRead, rightRead);
+
+      for (let index = 0; index < readLength; index += 1) {
+        const offset = position + index;
+        if (leftView[index] !== rightView[index]) {
+          differingBytes += 1;
+          if (currentStart === null) currentStart = offset;
+          currentEnd = offset;
+        } else if (currentStart !== null) {
+          pushRange(ranges, currentStart, currentEnd, maxRanges);
+          currentStart = null;
+          currentEnd = null;
+        }
+      }
+
+      position += readLength;
+    }
+  } finally {
+    if (leftHandle) await leftHandle.close();
+    if (rightHandle) await rightHandle.close();
+  }
+
+  if (currentStart !== null) {
+    pushRange(ranges, currentStart, currentEnd, maxRanges);
+  }
+
+  if (leftStat.size !== rightStat.size) {
+    const start = comparedLength;
+    const end = Math.max(leftStat.size, rightStat.size) - 1;
+    differingBytes += end - start + 1;
+    pushRange(ranges, start, end, maxRanges);
+  }
+
+  const [leftSha256, rightSha256] = await Promise.all([
+    hashFile(leftPath),
+    hashFile(rightPath),
+  ]);
+
+  return {
+    kind: 'file',
+    equal: leftSha256 === rightSha256 && leftStat.size === rightStat.size,
+    left: { path: leftPath, size: leftStat.size, sha256: leftSha256 },
+    right: { path: rightPath, size: rightStat.size, sha256: rightSha256 },
+    comparedBytes: comparedLength,
+    differingBytes,
+    differenceRanges: ranges,
+    truncatedRanges: ranges.length >= maxRanges,
+  };
+}
+
+async function listDirectoryFiles(rootDir) {
+  const files = [];
+
+  async function walk(currentDir, relativeDir) {
+    const entries = await fs.readdir(currentDir, { withFileTypes: true });
+    for (const entry of entries) {
+      const absolutePath = path.join(currentDir, entry.name);
+      const relativePath = normalizeRelativePath(path.join(relativeDir, entry.name));
+      if (entry.isDirectory()) {
+        await walk(absolutePath, relativePath);
+      } else if (entry.isFile()) {
+        const stat = await fs.stat(absolutePath);
+        files.push({
+          path: relativePath,
+          absolutePath,
+          size: stat.size,
+          sha256: await hashFile(absolutePath),
+        });
+      }
+    }
+  }
+
+  await walk(rootDir, '');
+  files.sort((a, b) => a.path.localeCompare(b.path));
+  return files;
+}
+
+async function compareDirectories(leftPath, rightPath) {
+  const [leftFiles, rightFiles] = await Promise.all([
+    listDirectoryFiles(leftPath),
+    listDirectoryFiles(rightPath),
+  ]);
+  const leftByPath = new Map(leftFiles.map(file => [file.path, file]));
+  const rightByPath = new Map(rightFiles.map(file => [file.path, file]));
+  const allPaths = Array.from(new Set([...leftByPath.keys(), ...rightByPath.keys()])).sort();
+  const changes = [];
+
+  for (const filePath of allPaths) {
+    const left = leftByPath.get(filePath);
+    const right = rightByPath.get(filePath);
+    if (!left) {
+      changes.push({ type: 'added', path: filePath, right: { size: right.size, sha256: right.sha256 } });
+    } else if (!right) {
+      changes.push({ type: 'removed', path: filePath, left: { size: left.size, sha256: left.sha256 } });
+    } else if (left.sha256 !== right.sha256 || left.size !== right.size) {
+      changes.push({
+        type: 'modified',
+        path: filePath,
+        left: { size: left.size, sha256: left.sha256 },
+        right: { size: right.size, sha256: right.sha256 },
+      });
+    }
+  }
+
+  return {
+    kind: 'directory',
+    equal: changes.length === 0,
+    left: { path: leftPath, fileCount: leftFiles.length },
+    right: { path: rightPath, fileCount: rightFiles.length },
+    changes,
+  };
+}
+
+function buildKnowledgeGraph(comparison) {
+  const nodes = [
+    { id: 'left', type: 'artifact', label: comparison.left.path },
+    { id: 'right', type: 'artifact', label: comparison.right.path },
+  ];
+  const edges = [{ from: 'left', to: 'right', type: comparison.equal ? 'matches' : 'differs_from' }];
+
+  if (comparison.kind === 'file') {
+    comparison.differenceRanges.forEach((range, index) => {
+      const nodeId = `range:${index + 1}`;
+      nodes.push({
+        id: nodeId,
+        type: 'byte_range',
+        label: `${range.start}-${range.end}`,
+        start: range.start,
+        end: range.end,
+        length: range.length,
+      });
+      edges.push({ from: 'left', to: nodeId, type: 'has_difference' });
+      edges.push({ from: 'right', to: nodeId, type: 'has_difference' });
+    });
+  } else {
+    comparison.changes.forEach((change, index) => {
+      const nodeId = `file:${index + 1}`;
+      nodes.push({
+        id: nodeId,
+        type: 'file_change',
+        label: change.path,
+        changeType: change.type,
+        path: change.path,
+      });
+      edges.push({ from: 'left', to: nodeId, type: change.type === 'added' ? 'missing' : 'contains' });
+      edges.push({ from: 'right', to: nodeId, type: change.type === 'removed' ? 'missing' : 'contains' });
+    });
+  }
+
+  return { nodes, edges };
+}
+
+export async function compareArtifacts(leftPath, rightPath, options = {}) {
+  const [leftStat, rightStat] = await Promise.all([statPath(leftPath), statPath(rightPath)]);
+  let comparison;
+
+  if (leftStat.isFile() && rightStat.isFile()) {
+    comparison = await compareFileBytes(leftPath, rightPath, options);
+  } else if (leftStat.isDirectory() && rightStat.isDirectory()) {
+    comparison = await compareDirectories(leftPath, rightPath);
+  } else {
+    throw new Error('Both compare inputs must be the same kind: two files or two directories.');
+  }
+
+  return {
+    ...comparison,
+    generatedAt: new Date().toISOString(),
+    knowledgeGraph: buildKnowledgeGraph(comparison),
+  };
+}


### PR DESCRIPTION
## Summary
- Add a standalone binary/directory comparison module for app artifacts.
- Add an `ipaship compare --file <left> --file <right>` CLI with text and JSON output.
- Emit SHA-256 fingerprints, byte difference ranges, directory file changes, and a small knowledge graph for downstream tooling.
- Document the compare command in the README.

Closes #97

## Test plan
- `node --check scripts/ipaship-cli.js`
- `node scripts/ipaship-cli.js compare --file README.md --file README.md`
- Directory diff smoke test with `--json` output parsed by `python3 -m json.tool`

## Notes
- This is intentionally scoped as a local compare CLI/module rather than a full visual Beyond Compare replacement.
- The CLI exits `0` when artifacts match, `1` when differences are found, and `2` for usage/runtime errors.
- Current Vercel status check appears to be a GitHub/Vercel authorization requirement for this fork/PR, not a code failure.
