### PR TITLE
fix: send selected provider api key with audits

### DIFF
--- a/src/app/api/audit/route.ts
+++ b/src/app/api/audit/route.ts
@@ -453,11 +453,11 @@ export async function POST(req: NextRequest) {
 
     // Stream-parse the multipart upload — writes file directly to disk
     // without ever loading the full file into memory
-    const { filePath, fileName, provider, model, context } = await parseMultipartStream(req, tempDir);
-    const resolvedApiKey = process.env.NVIDIA_KEY || process.env.NEXT_PUBLIC_API_KEY || '';
+    const { filePath, fileName, apiKey, provider, model, context } = await parseMultipartStream(req, tempDir);
+    const resolvedApiKey = apiKey || process.env.NVIDIA_KEY || process.env.NEXT_PUBLIC_API_KEY || '';
 
     if (!resolvedApiKey || !resolvedApiKey.trim()) {
-      return NextResponse.json({ error: 'API key is required in environment variables' }, { status: 500 });
+      return NextResponse.json({ error: 'API key is required' }, { status: 400 });
     }
 
     // Only accept .ipa, .apk, .zip files

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -63,6 +63,7 @@ export default function AuditPage() {
   const [provider, setProvider] = useState('ipaship');
   const [model, setModel] = useState('glm-5.1');
   const [context, setContext] = useState('');
+  const [apiKey, setApiKey] = useState('');
   const [phase, setPhase] = useState<AuditPhase>('idle');
   const [reportContent, setReportContent] = useState('');
   const [errorMessage, setErrorMessage] = useState('');
@@ -269,6 +270,7 @@ export default function AuditPage() {
         formData.append('provider', provider);
         formData.append('model', model);
         formData.append('context', context);
+        formData.append('apiKey', apiKey.trim());
         response = await fetch('/api/audit', { method: 'POST', body: formData });
       } else {
         // Fallback: upload + audit in one go
@@ -278,6 +280,7 @@ export default function AuditPage() {
         formData.append('provider', provider);
         formData.append('model', model);
         formData.append('context', context);
+        formData.append('apiKey', apiKey.trim());
         response = await fetch('/api/audit', { method: 'POST', body: formData });
         setPhase('analyzing');
       }
@@ -865,6 +868,23 @@ export default function AuditPage() {
                       </div>
 
                       {/* API Key */}
+                      <div className="space-y-2">
+                        <div className="flex items-center gap-2">
+                          <Key className="w-3.5 h-3.5 text-amber-400" />
+                          <span className="text-xs font-semibold text-white">API Key</span>
+                        </div>
+                        <input
+                          type="password"
+                          value={apiKey}
+                          onChange={(e) => setApiKey(e.target.value)}
+                          placeholder={provider === 'ipaship' ? 'NVIDIA API key' : `Your ${providerModels[provider]?.[0] ? provider : 'provider'} API key`}
+                          autoComplete="off"
+                          className="w-full bg-white/5 border border-white/10 rounded-xl px-3 py-2.5 text-xs text-white placeholder:text-muted-foreground/50 focus:outline-none focus:border-primary/50 focus:ring-1 focus:ring-primary/50 transition-all"
+                        />
+                        <p className="text-[10px] text-muted-foreground/60">
+                          Sent only with this audit request. Server environment keys are used as fallback when configured.
+                        </p>
+                      </div>
 
                       {/* Context */}
                       <div className="flex-1 flex flex-col space-y-2">


### PR DESCRIPTION
## Summary

Fixes #85 by wiring the user-provided API key through the audit flow for every provider, including ipaShip/NVIDIA.

Changes:
- Adds an API key password field to the audit form
- Sends the key with both uploaded-file and one-shot audit flows
- Uses the submitted key in `/api/audit`, with environment keys as fallback
- Returns a client error when no key is available instead of a server-only env error

## Verification

- `npm run build`

Note: Next.js prints an existing workspace-root/lockfile warning in this checkout, but the production build completes successfully.
