### PR TITLE
fix: use repository slug for github stars api

### DIFF
--- a/src/app/api/github-stars/route.ts
+++ b/src/app/api/github-stars/route.ts
@@ -8,7 +8,7 @@ const starsCache = new LRUCache<string, number>({
   ttl: 1000 * 60 * 5, // 5 minutes
 });
 
-const REPO = 'https://github.com/atharvnaik1/GraciasAi-Appstore-Policy-Auditor-Opensource';
+const REPO = 'atharvnaik1/ipaship-app-reviewer';
 const CACHE_KEY = 'stars';
 
 export async function GET() {


### PR DESCRIPTION
## Summary

Fixes one of the minor app issues from #86: the GitHub stars API route was building an invalid GitHub API URL because `REPO` contained a full GitHub web URL instead of the `owner/repo` slug expected by `https://api.github.com/repos/{owner}/{repo}`.

Changes:
- Replace the full GitHub URL with `atharvnaik1/ipaship-app-reviewer`
- Keeps the existing cache and fallback behavior unchanged

## Verification

- `npm run build`
- Verified the corrected GitHub API repo slug resolves with `gh api repos/atharvnaik1/ipaship-app-reviewer`

Note: Next.js prints an existing workspace-root/lockfile warning in this checkout, but the production build completes successfully.
