### PR TITLE
Fix NVIDIA API key support

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,11 +8,11 @@ AI-powered iOS App Store compliance auditor. Upload your `.ipa` file and get a c
 
 - **IPA Analysis** — Upload `.ipa` files (up to 150MB) for automated compliance auditing
 - **Full Guidelines Coverage** — Checks all 6 major App Store Review Guideline categories: Safety, Performance, Business, Design, Legal & Privacy, and Technical
-- **Multi-Provider AI** — Bring your own key from Anthropic (Claude), OpenAI (GPT), Google Gemini, or OpenRouter
-- **Model Selection** — Choose specific models per provider (Claude Sonnet 4, GPT-4o, Gemini 2.5 Flash, etc.)
+- **Multi-Provider AI** — Bring your own key from NVIDIA NIM, Anthropic (Claude), OpenAI (GPT), Google Gemini, or OpenRouter
+- **Model Selection** — Choose specific models per provider (NVIDIA Llama/Nemotron, Claude Sonnet 4, GPT-4o, Gemini 2.5 Flash, etc.)
 - **Real-Time Streaming** — Watch your audit report generate live as the AI analyzes your code
 - **Export Reports** — Download as Markdown or PDF
-- **Zero-Trust Security** — Files processed in ephemeral temp storage and deleted immediately. API keys stay in your browser, never on our servers
+- **Zero-Trust Security** — Files processed in ephemeral temp storage and deleted immediately. API keys are used only for the selected provider request and are never stored
 - **100% Open Source** — Fully auditable codebase
 
 ## Tech Stack
@@ -22,7 +22,7 @@ AI-powered iOS App Store compliance auditor. Upload your `.ipa` file and get a c
 | Frontend | Next.js 15, React 19, TypeScript, Tailwind CSS, Framer Motion |
 | Backend | Next.js API Routes (Node.js) |
 | Database | MongoDB (Mongoose) |
-| AI Providers | Anthropic, OpenAI, Google Gemini, OpenRouter |
+| AI Providers | NVIDIA NIM, Anthropic, OpenAI, Google Gemini, OpenRouter |
 | File Processing | Busboy (streaming uploads), `unzip` (IPA extraction) |
 | Export | html2pdf.js, React Markdown |
 
@@ -194,7 +194,7 @@ The script sets up Node.js 20, PM2, Nginx (with streaming/upload support), and U
 ## Security
 
 - **No cloud storage** — Files are processed in ephemeral `/tmp` directories and deleted immediately after audit
-- **BYOK (Bring Your Own Key)** — API keys are stored in your browser's localStorage, never sent to our servers
+- **BYOK (Bring Your Own Key)** — API keys are stored in your browser's localStorage and sent only for the selected audit request, never persisted server-side
 - **No shell injection** — File extraction uses `execFile` (no shell), preventing command injection via filenames
 - **Binary detection** — Binary plists and compiled files are detected and skipped
 - **Rate limiting** — 5 requests per IP per minute via in-memory LRU cache

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
   "scripts": {
     "dev": "next dev",
     "build": "next build",
-    "start": "next start -H 0.0.0.0 -p 8080"
+    "start": "next start -H 0.0.0.0 -p 8080",
+    "test": "node --test src/app/api/audit/provider-utils.test.mjs"
   },
   "keywords": [],
   "author": "",

--- a/src/app/api/audit/provider-utils.test.mjs
+++ b/src/app/api/audit/provider-utils.test.mjs
@@ -1,0 +1,62 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {
+  extractTextFromProviderChunk,
+  resolveProviderApiKey,
+} from './provider-utils.ts';
+
+test('resolveProviderApiKey prefers NVIDIA keys for NVIDIA provider', () => {
+  const key = resolveProviderApiKey('nvidia', '', {
+    NVIDIA_API_KEY: 'nvapi-key',
+    ANTHROPIC_API_KEY: 'claude-key',
+  });
+
+  assert.equal(key, 'nvapi-key');
+});
+
+test('resolveProviderApiKey prefers Anthropic keys for Claude provider', () => {
+  const key = resolveProviderApiKey('anthropic', '', {
+    NVIDIA_API_KEY: 'nvapi-key',
+    ANTHROPIC_API_KEY: 'claude-key',
+  });
+
+  assert.equal(key, 'claude-key');
+});
+
+test('resolveProviderApiKey lets user supplied key override environment keys', () => {
+  const key = resolveProviderApiKey('nvidia', ' user-key ', {
+    NVIDIA_API_KEY: 'nvapi-key',
+  });
+
+  assert.equal(key, 'user-key');
+});
+
+test('extractTextFromProviderChunk supports Anthropic message deltas', () => {
+  const text = extractTextFromProviderChunk('anthropic', {
+    delta: { text: 'claude text' },
+  });
+
+  assert.equal(text, 'claude text');
+});
+
+test('extractTextFromProviderChunk supports NVIDIA/OpenAI chat completion chunks', () => {
+  const text = extractTextFromProviderChunk('nvidia', {
+    choices: [{ delta: { content: 'nvidia text' } }],
+  });
+
+  assert.equal(text, 'nvidia text');
+});
+
+test('extractTextFromProviderChunk supports Gemini stream chunks', () => {
+  const text = extractTextFromProviderChunk('gemini', {
+    candidates: [
+      {
+        content: {
+          parts: [{ text: 'gemini text' }],
+        },
+      },
+    ],
+  });
+
+  assert.equal(text, 'gemini text');
+});

--- a/src/app/api/audit/provider-utils.ts
+++ b/src/app/api/audit/provider-utils.ts
@@ -1,0 +1,48 @@
+type Env = Record<string, string | undefined>;
+
+const PROVIDER_ENV_KEYS: Record<string, string[]> = {
+  nvidia: ['NVIDIA_API_KEY', 'NVIDIA_KEY', 'NEXT_PUBLIC_NVIDIA_API_KEY', 'NEXT_PUBLIC_API_KEY'],
+  ipaship: ['NVIDIA_API_KEY', 'NVIDIA_KEY', 'NEXT_PUBLIC_NVIDIA_API_KEY', 'NEXT_PUBLIC_API_KEY'],
+  anthropic: ['ANTHROPIC_API_KEY', 'CLAUDE_API_KEY', 'NEXT_PUBLIC_ANTHROPIC_API_KEY'],
+  openai: ['OPENAI_API_KEY', 'NEXT_PUBLIC_OPENAI_API_KEY'],
+  gemini: ['GEMINI_API_KEY', 'GOOGLE_API_KEY', 'NEXT_PUBLIC_GEMINI_API_KEY'],
+  openrouter: ['OPENROUTER_API_KEY', 'NEXT_PUBLIC_OPENROUTER_API_KEY'],
+};
+
+export function resolveProviderApiKey(
+  provider: string,
+  userProvidedKey: string | undefined,
+  env: Env = process.env
+): string {
+  const trimmedUserKey = userProvidedKey?.trim();
+  if (trimmedUserKey) return trimmedUserKey;
+
+  const keys = PROVIDER_ENV_KEYS[provider] || [];
+  for (const key of keys) {
+    const value = env[key]?.trim();
+    if (value) return value;
+  }
+
+  return '';
+}
+
+export function extractTextFromProviderChunk(
+  provider: string,
+  parsed: any
+): string {
+  if (!parsed) return '';
+
+  if (provider === 'anthropic') {
+    return parsed.delta?.text || '';
+  }
+
+  if (provider === 'gemini') {
+    return (
+      parsed.candidates?.[0]?.content?.parts
+        ?.map((part: any) => part?.text || '')
+        .join('') || ''
+    );
+  }
+
+  return parsed.choices?.[0]?.delta?.content || parsed.choices?.[0]?.message?.content || '';
+}

--- a/src/app/api/audit/route.ts
+++ b/src/app/api/audit/route.ts
@@ -8,6 +8,7 @@ import { Readable } from 'stream';
 import Busboy from 'busboy';
 import { LRUCache } from 'lru-cache';
 import { buildRetrievedContext, type SourceFile } from '../../../utils/audit-retrieval';
+import { extractTextFromProviderChunk, resolveProviderApiKey } from './provider-utils';
 
 const execFileAsync = promisify(execFile);
 
@@ -453,11 +454,11 @@ export async function POST(req: NextRequest) {
 
     // Stream-parse the multipart upload — writes file directly to disk
     // without ever loading the full file into memory
-    const { filePath, fileName, provider, model, context } = await parseMultipartStream(req, tempDir);
-    const resolvedApiKey = process.env.NVIDIA_KEY || process.env.NEXT_PUBLIC_API_KEY || '';
+    const { filePath, fileName, apiKey, provider, model, context } = await parseMultipartStream(req, tempDir);
+    const resolvedApiKey = resolveProviderApiKey(provider, apiKey);
 
     if (!resolvedApiKey || !resolvedApiKey.trim()) {
-      return NextResponse.json({ error: 'API key is required in environment variables' }, { status: 500 });
+      return NextResponse.json({ error: `API key is required for ${provider}` }, { status: 400 });
     }
 
     // Only accept .ipa, .apk, .zip files
@@ -492,7 +493,7 @@ export async function POST(req: NextRequest) {
     let headers: Record<string, string> = { 'Content-Type': 'application/json' };
     let payload: any = {};
 
-    const VALID_PROVIDERS = new Set(['ipaship', 'anthropic', 'openai', 'gemini', 'openrouter']);
+    const VALID_PROVIDERS = new Set(['nvidia', 'ipaship', 'anthropic', 'openai', 'gemini', 'openrouter']);
     if (!VALID_PROVIDERS.has(provider)) {
       return NextResponse.json({ error: `Invalid provider: ${provider}` }, { status: 400 });
     }
@@ -535,13 +536,13 @@ export async function POST(req: NextRequest) {
           { role: 'user', content: userPrompt },
         ],
       };
-    } else if (provider === 'ipaship') {
-      // ipaShip AI uses NVIDIA NIM endpoints natively
+    } else if (provider === 'nvidia' || provider === 'ipaship') {
+      // NVIDIA NIM-compatible chat completions endpoint
       apiUrl = 'https://integrate.api.nvidia.com/v1/chat/completions';
       headers['Authorization'] = `Bearer ${resolvedApiKey.trim()}`;
       payload = {
         model: model || 'meta/llama-3.1-405b-instruct',
-        max_tokens: 4096,
+        max_tokens: 8192,
         stream: true,
         messages: [
           { role: 'system', content: systemPrompt },
@@ -567,10 +568,14 @@ export async function POST(req: NextRequest) {
       method: 'POST',
       headers,
       body: JSON.stringify(payload),
+      signal: abortController.signal,
     });
 
     if (!response.ok) {
-      return NextResponse.json({ error: 'AI request failed' }, { status: response.status });
+      const errorText = await response.text().catch(() => '');
+      return NextResponse.json({
+        error: errorText || `${provider} AI request failed`,
+      }, { status: response.status });
     }
 
     const stream = new ReadableStream({
@@ -597,7 +602,7 @@ export async function POST(req: NextRequest) {
                 if (data === '[DONE]') continue;
                 try {
                   const parsed = JSON.parse(data);
-                  const textFragment = parsed.delta?.text || '';
+                  const textFragment = extractTextFromProviderChunk(provider, parsed);
                   if (textFragment) {
                     controller.enqueue(encoder.encode(JSON.stringify({ type: 'content', text: textFragment }) + '\n'));
                   }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -17,6 +17,11 @@ import { UserButton, SignedOut, SignedIn, useAuth, useClerk } from '@clerk/nextj
 type AuditPhase = 'idle' | 'uploading' | 'analyzing' | 'complete' | 'error';
 
 const providerModels: Record<string, { label: string; value: string }[]> = {
+  nvidia: [
+    { label: 'Llama 3.1 405B', value: 'meta/llama-3.1-405b-instruct' },
+    { label: 'Llama 3.1 70B', value: 'meta/llama-3.1-70b-instruct' },
+    { label: 'Nemotron Ultra', value: 'nvidia/llama-3.1-nemotron-ultra-253b-v1' },
+  ],
   anthropic: [
     { label: 'Claude Sonnet 4', value: 'claude-sonnet-4-20250514' },
     { label: 'Claude 3.5 Sonnet', value: 'claude-3-5-sonnet-20241022' },
@@ -60,8 +65,9 @@ const selectStyle = {
 
 export default function AuditPage() {
   const [file, setFile] = useState<File | null>(null);
-  const [provider, setProvider] = useState('ipaship');
-  const [model, setModel] = useState('glm-5.1');
+  const [provider, setProvider] = useState('nvidia');
+  const [model, setModel] = useState('meta/llama-3.1-405b-instruct');
+  const [apiKey, setApiKey] = useState('');
   const [context, setContext] = useState('');
   const [phase, setPhase] = useState<AuditPhase>('idle');
   const [reportContent, setReportContent] = useState('');
@@ -98,6 +104,11 @@ export default function AuditPage() {
       .then(data => { setStarCount(data.stars ?? 0); })
       .catch(() => { setStarCount(0); });
   }, []);
+
+  useEffect(() => {
+    const savedKey = window.localStorage.getItem(`ipaship:${provider}:api-key`) || '';
+    setApiKey(savedKey);
+  }, [provider]);
 
 
   // Auto-start audit as soon as upload finishes
@@ -268,6 +279,7 @@ export default function AuditPage() {
         formData.append('fileName', file.name);
         formData.append('provider', provider);
         formData.append('model', model);
+        formData.append('apiKey', apiKey);
         formData.append('context', context);
         response = await fetch('/api/audit', { method: 'POST', body: formData });
       } else {
@@ -277,6 +289,7 @@ export default function AuditPage() {
         formData.append('file', file);
         formData.append('provider', provider);
         formData.append('model', model);
+        formData.append('apiKey', apiKey);
         formData.append('context', context);
         response = await fetch('/api/audit', { method: 'POST', body: formData });
         setPhase('analyzing');
@@ -846,6 +859,7 @@ export default function AuditPage() {
                           className="w-full bg-white/5 border border-white/10 text-xs text-white font-medium px-3 py-2.5 rounded-xl outline-none focus:ring-1 focus:ring-primary/50 appearance-none cursor-pointer hover:bg-white/[0.08] transition-colors"
                           style={selectStyle}
                         >
+                          <option value="nvidia">NVIDIA NIM</option>
                           <option value="ipaship">ipaShip AI</option>
                           <option value="anthropic">Anthropic (Claude)</option>
                           <option value="openai">OpenAI (GPT)</option>
@@ -865,6 +879,33 @@ export default function AuditPage() {
                       </div>
 
                       {/* API Key */}
+                      <div className="space-y-2">
+                        <div className="flex items-center gap-2">
+                          <Key className="w-3.5 h-3.5 text-green-400" />
+                          <span className="text-xs font-semibold text-white">API Key</span>
+                        </div>
+                        <input
+                          type="password"
+                          value={apiKey}
+                          onChange={(e) => {
+                            const value = e.target.value;
+                            setApiKey(value);
+                            if (value.trim()) {
+                              window.localStorage.setItem(`ipaship:${provider}:api-key`, value);
+                            } else {
+                              window.localStorage.removeItem(`ipaship:${provider}:api-key`);
+                            }
+                          }}
+                          placeholder={
+                            provider === 'nvidia' || provider === 'ipaship'
+                              ? 'NVIDIA API key'
+                              : provider === 'anthropic'
+                                ? 'Anthropic API key'
+                                : `${provider} API key`
+                          }
+                          className="w-full bg-white/5 border border-white/10 rounded-xl px-3 py-2.5 text-xs text-white placeholder:text-muted-foreground/50 focus:outline-none focus:border-green-500/50 focus:ring-1 focus:ring-green-500/50 transition-all"
+                        />
+                      </div>
 
                       {/* Context */}
                       <div className="flex-1 flex flex-col space-y-2">
@@ -943,7 +984,7 @@ export default function AuditPage() {
                       icon: <Lock className="w-5 h-5 text-green-400" />,
                       iconBg: 'bg-green-500/10 border-green-500/20',
                       title: 'Zero Trust Security',
-                      desc: 'Your code is processed in ephemeral temp storage and deleted immediately. API keys stay in your browser, never on our servers.',
+                      desc: 'Your code is processed in ephemeral temp storage and deleted immediately. API keys are used only for the selected provider request.',
                     },
                     {
                       icon: <Code2 className="w-5 h-5 text-blue-400" />,
@@ -955,7 +996,7 @@ export default function AuditPage() {
                       icon: <Cpu className="w-5 h-5 text-purple-400" />,
                       iconBg: 'bg-purple-500/10 border-purple-500/20',
                       title: 'Multi-Provider BYOK',
-                      desc: 'Bring your own key from Anthropic, OpenAI, Google Gemini, or OpenRouter. Choose the model that works best for you.',
+                      desc: 'Bring your own key from NVIDIA NIM, Anthropic, OpenAI, Google Gemini, or OpenRouter. Choose the model that works best for you.',
                     },
                     {
                       icon: <FileText className="w-5 h-5 text-cyan-400" />,
@@ -1056,7 +1097,7 @@ export default function AuditPage() {
                       <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
                         {[
                           { title: 'No Cloud Storage', desc: 'Files are processed in ephemeral temp directories and deleted immediately after audit.' },
-                          { title: 'Bring Your Own Key', desc: 'Your API key goes directly to your AI provider. We never store or log it.' },
+                          { title: 'Bring Your Own Key', desc: 'Your API key is used only for the selected audit request. We never store or log it.' },
                           { title: 'Fully Auditable', desc: 'Read every line of our open-source code on GitHub. Full transparency.' },
                         ].map((item) => (
                           <div key={item.title} className="flex gap-3">


### PR DESCRIPTION
Fixes #85

## Summary
- Adds NVIDIA NIM as an explicit AI provider in the audit UI.
- Sends the selected provider API key with audit requests.
- Resolves provider-specific API keys on the backend instead of using one global key for all providers.
- Supports NVIDIA/OpenAI-style streaming chunks, Anthropic chunks, and Gemini chunks.
- Updates README/provider copy to mention NVIDIA support.

## Verification
- npm test
- npx tsc --noEmit
- npm run build

Note: `npm run build` passes. Next.js logs warnings about missing SWC lockfile entries and failed registry fetches while trying to patch the lockfile, but the production build exits successfully.