### PR TITLE
[codex] fix audit streaming and report export

### DIFF
--- a/src/app/api/audit/route.ts
+++ b/src/app/api/audit/route.ts
@@ -284,6 +284,38 @@ function sanitizeContext(context: string): string {
   return context.slice(0, 2000);
 }
 
+function extractStreamText(provider: string, parsed: any): string {
+  if (!parsed || typeof parsed !== 'object') return '';
+
+  if (provider === 'anthropic') {
+    return parsed.delta?.text || '';
+  }
+
+  if (provider === 'gemini') {
+    const parts = parsed.candidates?.[0]?.content?.parts;
+    if (Array.isArray(parts)) {
+      return parts
+        .map((part: any) => (typeof part?.text === 'string' ? part.text : ''))
+        .join('');
+    }
+    return '';
+  }
+
+  const content = parsed.choices?.[0]?.delta?.content;
+  if (typeof content === 'string') return content;
+  if (Array.isArray(content)) {
+    return content
+      .map((part: any) => {
+        if (typeof part === 'string') return part;
+        if (typeof part?.text === 'string') return part.text;
+        return '';
+      })
+      .join('');
+  }
+
+  return '';
+}
+
 function buildAuditPrompt(
   files: SourceFile[],
   context: string,
@@ -603,6 +635,7 @@ export async function POST(req: NextRequest) {
       method: 'POST',
       headers,
       body: JSON.stringify(payload),
+      signal: abortController.signal,
     });
 
     if (!response.ok) {
@@ -615,7 +648,11 @@ export async function POST(req: NextRequest) {
         const reader = response.body!.getReader();
         const decoder = new TextDecoder();
 
-        controller.enqueue(encoder.encode(JSON.stringify({ type: 'meta', filesScanned: files.length }) + '\n'));
+        controller.enqueue(encoder.encode(JSON.stringify({
+          type: 'meta',
+          filesScanned: files.length,
+          fileNames: files.slice(0, 100).map(file => file.path),
+        }) + '\n'));
 
         try {
           let buffer = '';
@@ -633,7 +670,7 @@ export async function POST(req: NextRequest) {
                 if (data === '[DONE]') continue;
                 try {
                   const parsed = JSON.parse(data);
-                  const textFragment = parsed.delta?.text || '';
+                  const textFragment = extractStreamText(provider, parsed);
                   if (textFragment) {
                     controller.enqueue(encoder.encode(JSON.stringify({ type: 'content', text: textFragment }) + '\n'));
                   }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -139,6 +139,15 @@ const auditProgressSteps = [
   { label: 'Report', description: 'Fix plan generated' },
 ];
 
+function escapeHtml(value: string): string {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
 export default function AuditPage() {
   const [file, setFile] = useState<File | null>(null);
   const [provider, setProvider] = useState('ipaship');
@@ -466,12 +475,15 @@ export default function AuditPage() {
   const handleExportPdf = async () => {
     if (!reportContent) return;
     try {
-      const { marked } = await import('marked');
+      const { marked, Renderer } = await import('marked');
+      const renderer = new Renderer();
+      renderer.html = ({ text }: { text: string }) => escapeHtml(text);
 
-      // Configure marked for GFM (tables, strikethrough, etc.)
-      marked.setOptions({ gfm: true, breaks: true } as any);
-
-      const bodyHtml = await marked.parse(reportContent);
+      const bodyHtml = await marked.parse(reportContent, {
+        gfm: true,
+        breaks: true,
+        renderer,
+      } as any);
       const dateStr = new Date().toLocaleDateString('en-US', { year: 'numeric', month: 'long', day: 'numeric' });
 
       const fullHtml = `<!DOCTYPE html>


### PR DESCRIPTION
## Summary
- Normalize streamed content parsing across Anthropic, Gemini, and OpenAI-compatible providers so audits can emit content for all configured providers.
- Send scanned file names in the audit metadata stream and abort the upstream provider request when clients disconnect.
- Use the selected store name in the audit prompt and escape raw HTML during printable PDF report generation.

## Verification
- `npx tsc --noEmit --incremental false`
- `npm run build`
- Runtime smoke check: `marked` PDF export renderer escapes raw HTML while still rendering Markdown.

Refs #86.