### PR TITLE
Add Gracias AI SVG logo pack

### DIFF
--- a/logo/README.md
+++ b/logo/README.md
@@ -1,0 +1,18 @@
+# Gracias AI Logo Pack
+
+This package provides original SVG logo variants for the Gracias AI App Store compliance auditor.
+
+## Files
+
+- `logomark.svg` - app-icon style mark for light backgrounds
+- `logomark-dark.svg` - app-icon style mark on a dark tile
+- `wordmark.svg` - logomark plus "Gracias AI" wordmark for light backgrounds
+- `wordmark-dark.svg` - logomark plus "Gracias AI" wordmark on a dark tile
+
+## Design Notes
+
+The mark combines a rounded app tile, a compliance shield, neural connection nodes, and a checkmark. It uses the requested brand colors `#a855f7`, `#3b82f6`, and white while avoiding direct platform trademark shapes.
+
+## Usage
+
+Use the logomark where space is constrained, such as favicons, app tiles, social avatars, and small UI badges. Use the wordmark for repository headers, documentation, launch pages, and social preview images.

--- a/logo/logomark-dark.svg
+++ b/logo/logomark-dark.svg
@@ -1,0 +1,31 @@
+<svg width="256" height="256" viewBox="0 0 256 256" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="title desc">
+  <title id="title">Gracias AI dark logomark</title>
+  <desc id="desc">A dark-background app tile containing a shield, neural nodes, and a compliance checkmark.</desc>
+  <defs>
+    <linearGradient id="tile" x1="36" y1="24" x2="220" y2="232" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#a855f7"/>
+      <stop offset="1" stop-color="#3b82f6"/>
+    </linearGradient>
+    <filter id="glow" x="18" y="18" width="220" height="220" color-interpolation-filters="sRGB" filterUnits="userSpaceOnUse">
+      <feDropShadow dx="0" dy="18" stdDeviation="18" flood-color="#3b82f6" flood-opacity=".28"/>
+    </filter>
+  </defs>
+
+  <rect width="256" height="256" rx="56" fill="#0f172a"/>
+  <rect x="24" y="24" width="208" height="208" rx="52" fill="url(#tile)" filter="url(#glow)"/>
+  <path d="M128 47 184 67v45c0 39-21 73-56 96-35-23-56-57-56-96V67l56-20Z" fill="#111827"/>
+  <path d="M128 47v161c35-23 56-57 56-96V67l-56-20Z" fill="#172554" opacity=".78"/>
+
+  <path d="M91 92h74" stroke="#60a5fa" stroke-width="8" stroke-linecap="round" opacity=".85"/>
+  <path d="M91 118h74" stroke="#c084fc" stroke-width="8" stroke-linecap="round" opacity=".85"/>
+  <path d="M91 144h74" stroke="#60a5fa" stroke-width="8" stroke-linecap="round" opacity=".85"/>
+
+  <circle cx="96" cy="92" r="8" fill="#c084fc"/>
+  <circle cx="160" cy="92" r="8" fill="#93c5fd"/>
+  <circle cx="128" cy="118" r="9" fill="#f5f3ff"/>
+  <circle cx="96" cy="144" r="8" fill="#93c5fd"/>
+  <circle cx="160" cy="144" r="8" fill="#c084fc"/>
+
+  <path d="m103 162 18 18 36-43" stroke="#4ade80" stroke-width="13" stroke-linecap="round" stroke-linejoin="round"/>
+  <path d="M128 48 184 68v44c0 39-21 73-56 96-35-23-56-57-56-96V68l56-20Z" stroke="#e0e7ff" stroke-width="6" stroke-linejoin="round" opacity=".65"/>
+</svg>

--- a/logo/logomark.svg
+++ b/logo/logomark.svg
@@ -1,0 +1,36 @@
+<svg width="256" height="256" viewBox="0 0 256 256" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="title desc">
+  <title id="title">Gracias AI logomark</title>
+  <desc id="desc">A rounded app tile containing a shield, neural nodes, and a compliance checkmark.</desc>
+  <defs>
+    <linearGradient id="tile" x1="36" y1="24" x2="220" y2="232" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#a855f7"/>
+      <stop offset="1" stop-color="#3b82f6"/>
+    </linearGradient>
+    <linearGradient id="shield" x1="75" y1="48" x2="181" y2="204" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#ffffff"/>
+      <stop offset="1" stop-color="#dbeafe"/>
+    </linearGradient>
+    <filter id="soft-shadow" x="21" y="21" width="214" height="214" color-interpolation-filters="sRGB" filterUnits="userSpaceOnUse">
+      <feDropShadow dx="0" dy="14" stdDeviation="14" flood-color="#1e1b4b" flood-opacity=".22"/>
+    </filter>
+  </defs>
+
+  <rect x="24" y="24" width="208" height="208" rx="52" fill="url(#tile)"/>
+  <g filter="url(#soft-shadow)">
+    <path d="M128 47 184 67v45c0 39-21 73-56 96-35-23-56-57-56-96V67l56-20Z" fill="url(#shield)"/>
+  </g>
+
+  <path d="M128 47v161c35-23 56-57 56-96V67l-56-20Z" fill="#eff6ff" opacity=".7"/>
+  <path d="M91 92h74" stroke="#93c5fd" stroke-width="8" stroke-linecap="round" opacity=".8"/>
+  <path d="M91 118h74" stroke="#c4b5fd" stroke-width="8" stroke-linecap="round" opacity=".8"/>
+  <path d="M91 144h74" stroke="#93c5fd" stroke-width="8" stroke-linecap="round" opacity=".8"/>
+
+  <circle cx="96" cy="92" r="8" fill="#a855f7"/>
+  <circle cx="160" cy="92" r="8" fill="#3b82f6"/>
+  <circle cx="128" cy="118" r="9" fill="#7c3aed"/>
+  <circle cx="96" cy="144" r="8" fill="#3b82f6"/>
+  <circle cx="160" cy="144" r="8" fill="#a855f7"/>
+
+  <path d="m103 162 18 18 36-43" stroke="#16a34a" stroke-width="13" stroke-linecap="round" stroke-linejoin="round"/>
+  <path d="M128 48 184 68v44c0 39-21 73-56 96-35-23-56-57-56-96V68l56-20Z" stroke="#ffffff" stroke-width="6" stroke-linejoin="round" opacity=".72"/>
+</svg>

--- a/logo/wordmark-dark.svg
+++ b/logo/wordmark-dark.svg
@@ -1,0 +1,29 @@
+<svg width="640" height="180" viewBox="0 0 640 180" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="title desc">
+  <title id="title">Gracias AI dark wordmark</title>
+  <desc id="desc">Dark-background Gracias AI wordmark with a shield and neural compliance logomark.</desc>
+  <rect width="640" height="180" rx="32" fill="#0f172a"/>
+  <defs>
+    <linearGradient id="tile" x1="18" y1="18" x2="146" y2="162" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#a855f7"/>
+      <stop offset="1" stop-color="#3b82f6"/>
+    </linearGradient>
+    <linearGradient id="word" x1="184" y1="42" x2="492" y2="119" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#ffffff"/>
+      <stop offset="1" stop-color="#93c5fd"/>
+    </linearGradient>
+  </defs>
+
+  <rect x="18" y="18" width="144" height="144" rx="38" fill="url(#tile)"/>
+  <path d="M90 36 129 50v31c0 27-14 51-39 67-25-16-39-40-39-67V50l39-14Z" fill="#111827"/>
+  <path d="M90 36v112c25-16 39-40 39-67V50L90 36Z" fill="#172554" opacity=".78"/>
+  <path d="M65 68h50M65 86h50M65 104h50" stroke="#60a5fa" stroke-width="6" stroke-linecap="round"/>
+  <circle cx="69" cy="68" r="6" fill="#c084fc"/>
+  <circle cx="111" cy="68" r="6" fill="#93c5fd"/>
+  <circle cx="90" cy="86" r="7" fill="#f5f3ff"/>
+  <circle cx="69" cy="104" r="6" fill="#93c5fd"/>
+  <circle cx="111" cy="104" r="6" fill="#c084fc"/>
+  <path d="m72 118 13 13 25-30" stroke="#4ade80" stroke-width="9" stroke-linecap="round" stroke-linejoin="round"/>
+
+  <text x="190" y="94" fill="url(#word)" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="58" font-weight="800">Gracias AI</text>
+  <text x="193" y="126" fill="#cbd5e1" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="18" font-weight="600" letter-spacing="2">APP STORE COMPLIANCE AUDITOR</text>
+</svg>

--- a/logo/wordmark.svg
+++ b/logo/wordmark.svg
@@ -1,0 +1,28 @@
+<svg width="640" height="180" viewBox="0 0 640 180" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="title desc">
+  <title id="title">Gracias AI wordmark</title>
+  <desc id="desc">Gracias AI wordmark with a shield and neural compliance logomark.</desc>
+  <defs>
+    <linearGradient id="tile" x1="18" y1="18" x2="146" y2="162" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#a855f7"/>
+      <stop offset="1" stop-color="#3b82f6"/>
+    </linearGradient>
+    <linearGradient id="word" x1="184" y1="42" x2="492" y2="119" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#111827"/>
+      <stop offset="1" stop-color="#1d4ed8"/>
+    </linearGradient>
+  </defs>
+
+  <rect x="18" y="18" width="144" height="144" rx="38" fill="url(#tile)"/>
+  <path d="M90 36 129 50v31c0 27-14 51-39 67-25-16-39-40-39-67V50l39-14Z" fill="#ffffff"/>
+  <path d="M90 36v112c25-16 39-40 39-67V50L90 36Z" fill="#dbeafe"/>
+  <path d="M65 68h50M65 86h50M65 104h50" stroke="#93c5fd" stroke-width="6" stroke-linecap="round"/>
+  <circle cx="69" cy="68" r="6" fill="#a855f7"/>
+  <circle cx="111" cy="68" r="6" fill="#3b82f6"/>
+  <circle cx="90" cy="86" r="7" fill="#7c3aed"/>
+  <circle cx="69" cy="104" r="6" fill="#3b82f6"/>
+  <circle cx="111" cy="104" r="6" fill="#a855f7"/>
+  <path d="m72 118 13 13 25-30" stroke="#16a34a" stroke-width="9" stroke-linecap="round" stroke-linejoin="round"/>
+
+  <text x="190" y="94" fill="url(#word)" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="58" font-weight="800">Gracias AI</text>
+  <text x="193" y="126" fill="#475569" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="18" font-weight="600" letter-spacing="2">APP STORE COMPLIANCE AUDITOR</text>
+</svg>


### PR DESCRIPTION
## Summary
- Add an original SVG logo pack for Gracias AI: light/dark logomarks and light/dark wordmarks.
- Use the requested purple/blue/white palette with a rounded app tile, compliance shield, neural nodes, and checkmark.
- Include usage notes in `logo/README.md` and avoid direct platform trademark shapes.

## Validation
- Parsed all SVGs as XML locally.
- `git diff --check` passed.

Refs #2
