### PR TITLE
Fix: Beyond compare like Binary Compare module and cli agent.

### DIFF
--- a/src/app/api/compare/route.ts
+++ b/src/app/api/compare/route.ts
@@ -1,0 +1,42 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { compareFiles } from '@/lib/binary-compare';
+
+export const dynamic = 'force-dynamic';
+
+export async function POST(request: NextRequest) {
+  try {
+    const body = await request.json() as { file1?: string; file2?: string };
+    const { file1, file2 } = body;
+
+    if (!file1 || typeof file1 !== 'string') {
+      return NextResponse.json({ error: 'file1 path is required' }, { status: 400 });
+    }
+    if (!file2 || typeof file2 !== 'string') {
+      return NextResponse.json({ error: 'file2 path is required' }, { status: 400 });
+    }
+
+    const result = await compareFiles(file1, file2);
+    return NextResponse.json(result);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : 'Comparison failed';
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}
+
+export async function GET(request: NextRequest) {
+  const { searchParams } = new URL(request.url);
+  const file1 = searchParams.get('file1');
+  const file2 = searchParams.get('file2');
+
+  if (!file1 || !file2) {
+    return NextResponse.json({ error: 'Query params file1 and file2 are required' }, { status: 400 });
+  }
+
+  try {
+    const result = await compareFiles(file1, file2);
+    return NextResponse.json(result);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : 'Comparison failed';
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}

--- a/src/lib/binary-compare.ts
+++ b/src/lib/binary-compare.ts
@@ -1,0 +1,240 @@
+import * as fs from 'fs';
+import * as crypto from 'crypto';
+import * as path from 'path';
+import { spawnSync } from 'child_process';
+import { buildKnowledgeGraph, KnowledgeGraph } from './knowledge-graph';
+
+export type FileType = 'binary' | 'text' | 'resource' | 'metadata' | 'archive';
+export type ChangeType = 'added' | 'removed' | 'modified' | 'unchanged';
+
+export interface ArchiveEntry {
+  path: string;
+  uncompressedSize: number;
+  compressedSize: number;
+  crc32: string;
+  method: string;
+}
+
+export interface FileChange {
+  path: string;
+  changeType: ChangeType;
+  before?: ArchiveEntry;
+  after?: ArchiveEntry;
+  sizeDelta: number;
+  crcChanged: boolean;
+}
+
+export interface DiffRegion {
+  offset: number;
+  length: number;
+  type: 'modified';
+  hexOffset: string;
+}
+
+export interface BinaryDiff {
+  file1Size: number;
+  file2Size: number;
+  sizeDelta: number;
+  sizeDeltaPercent: number;
+  similarity: number;
+  totalBytesCompared: number;
+  diffBytes: number;
+  diffRegions: DiffRegion[];
+  isIdentical: boolean;
+}
+
+export interface ComparisonSummary {
+  file1Path: string;
+  file2Path: string;
+  file1Name: string;
+  file2Name: string;
+  file1Size: number;
+  file2Size: number;
+  file1Hash: string;
+  file2Hash: string;
+  isIdentical: boolean;
+  isArchive: boolean;
+  added: number;
+  removed: number;
+  modified: number;
+  unchanged: number;
+  totalFiles1: number;
+  totalFiles2: number;
+  sizeDelta: number;
+  sizeDeltaPercent: number;
+}
+
+export interface CompareResult {
+  summary: ComparisonSummary;
+  binaryDiff: BinaryDiff;
+  fileChanges: FileChange[];
+  knowledgeGraph: KnowledgeGraph;
+  generatedAt: string;
+}
+
+const ARCHIVE_EXTENSIONS = new Set(['.ipa', '.apk', '.zip', '.jar', '.aab', '.xcarchive']);
+const MAX_BINARY_COMPARE_BYTES = 10 * 1024 * 1024; // 10 MB cap for byte-level scan
+const MAX_DIFF_REGIONS = 100;
+
+function hashFile(filePath: string): string {
+  const buf = fs.readFileSync(filePath);
+  return crypto.createHash('sha256').update(buf).digest('hex');
+}
+
+function isArchiveFile(filePath: string): boolean {
+  return ARCHIVE_EXTENSIONS.has(path.extname(filePath).toLowerCase());
+}
+
+function listArchiveEntries(filePath: string): ArchiveEntry[] {
+  // unzip -v prints: Length  Method  Size  Cmpr  Date  Time  CRC-32  Name
+  const result = spawnSync('unzip', ['-v', filePath], { encoding: 'utf8', maxBuffer: 64 * 1024 * 1024 });
+  if (result.error || result.status !== 0) return [];
+
+  const entries: ArchiveEntry[] = [];
+  const lines = result.stdout.split('\n');
+
+  for (const line of lines) {
+    // Match lines like: "  12345  Defl:N   6789  45%  2024-01-01 12:00  abcdef01  path/to/file"
+    const m = line.match(/^\s*(\d+)\s+(\S+)\s+(\d+)\s+\S+\s+\S+\s+\S+\s+([0-9a-fA-F]{8})\s+(.+)$/);
+    if (!m) continue;
+    const entryPath = m[5].trim();
+    if (entryPath.endsWith('/')) continue; // skip directories
+    entries.push({
+      path: entryPath,
+      uncompressedSize: parseInt(m[1], 10),
+      compressedSize: parseInt(m[3], 10),
+      method: m[2],
+      crc32: m[4].toLowerCase(),
+    });
+  }
+  return entries;
+}
+
+function computeBinaryDiff(file1Path: string, file2Path: string): BinaryDiff {
+  const buf1 = fs.readFileSync(file1Path);
+  const buf2 = fs.readFileSync(file2Path);
+  const file1Size = buf1.length;
+  const file2Size = buf2.length;
+  const sizeDelta = file2Size - file1Size;
+  const sizeDeltaPercent = file1Size > 0 ? (sizeDelta / file1Size) * 100 : 0;
+  const isIdentical = buf1.equals(buf2);
+
+  if (isIdentical) {
+    return { file1Size, file2Size, sizeDelta: 0, sizeDeltaPercent: 0, similarity: 100, totalBytesCompared: file1Size, diffBytes: 0, diffRegions: [], isIdentical: true };
+  }
+
+  const compareLen = Math.min(buf1.length, buf2.length, MAX_BINARY_COMPARE_BYTES);
+  let diffBytes = 0;
+  const diffRegions: DiffRegion[] = [];
+  let inDiff = false;
+  let diffStart = 0;
+
+  for (let i = 0; i < compareLen; i++) {
+    if (buf1[i] !== buf2[i]) {
+      diffBytes++;
+      if (!inDiff) { inDiff = true; diffStart = i; }
+    } else if (inDiff) {
+      inDiff = false;
+      if (diffRegions.length < MAX_DIFF_REGIONS) {
+        diffRegions.push({ offset: diffStart, length: i - diffStart, type: 'modified', hexOffset: `0x${diffStart.toString(16).toUpperCase()}` });
+      }
+    }
+  }
+  if (inDiff && diffRegions.length < MAX_DIFF_REGIONS) {
+    diffRegions.push({ offset: diffStart, length: compareLen - diffStart, type: 'modified', hexOffset: `0x${diffStart.toString(16).toUpperCase()}` });
+  }
+
+  const similarity = compareLen > 0 ? Math.round(((compareLen - diffBytes) / compareLen) * 10000) / 100 : 0;
+
+  return { file1Size, file2Size, sizeDelta, sizeDeltaPercent: Math.round(sizeDeltaPercent * 100) / 100, similarity, totalBytesCompared: compareLen, diffBytes, diffRegions, isIdentical: false };
+}
+
+function diffArchiveEntries(entries1: ArchiveEntry[], entries2: ArchiveEntry[]): { changes: FileChange[]; added: number; removed: number; modified: number; unchanged: number } {
+  const map1 = new Map(entries1.map(e => [e.path, e]));
+  const map2 = new Map(entries2.map(e => [e.path, e]));
+  const changes: FileChange[] = [];
+  let added = 0, removed = 0, modified = 0, unchanged = 0;
+
+  for (const [p, e] of map2) {
+    if (!map1.has(p)) {
+      changes.push({ path: p, changeType: 'added', after: e, sizeDelta: e.uncompressedSize, crcChanged: true });
+      added++;
+    }
+  }
+  for (const [p, e] of map1) {
+    if (!map2.has(p)) {
+      changes.push({ path: p, changeType: 'removed', before: e, sizeDelta: -e.uncompressedSize, crcChanged: true });
+      removed++;
+    }
+  }
+  for (const [p, e1] of map1) {
+    const e2 = map2.get(p);
+    if (!e2) continue;
+    const crcChanged = e1.crc32 !== e2.crc32;
+    if (crcChanged || e1.uncompressedSize !== e2.uncompressedSize) {
+      changes.push({ path: p, changeType: 'modified', before: e1, after: e2, sizeDelta: e2.uncompressedSize - e1.uncompressedSize, crcChanged });
+      modified++;
+    } else {
+      changes.push({ path: p, changeType: 'unchanged', before: e1, after: e2, sizeDelta: 0, crcChanged: false });
+      unchanged++;
+    }
+  }
+
+  changes.sort((a, b) => {
+    const order: Record<ChangeType, number> = { added: 0, removed: 1, modified: 2, unchanged: 3 };
+    return order[a.changeType] - order[b.changeType];
+  });
+
+  return { changes, added, removed, modified, unchanged };
+}
+
+export async function compareFiles(file1Path: string, file2Path: string): Promise<CompareResult> {
+  for (const p of [file1Path, file2Path]) {
+    if (!fs.existsSync(p)) throw new Error(`File not found: ${p}`);
+    const stat = fs.statSync(p);
+    if (!stat.isFile()) throw new Error(`Not a file: ${p}`);
+  }
+
+  const file1Stat = fs.statSync(file1Path);
+  const file2Stat = fs.statSync(file2Path);
+  const file1Hash = hashFile(file1Path);
+  const file2Hash = hashFile(file2Path);
+  const isIdentical = file1Hash === file2Hash;
+  const archiveMode = isArchiveFile(file1Path) || isArchiveFile(file2Path);
+
+  const binaryDiff = computeBinaryDiff(file1Path, file2Path);
+
+  let fileChanges: FileChange[] = [];
+  let added = 0, removed = 0, modified = 0, unchanged = 0;
+
+  if (archiveMode) {
+    const entries1 = listArchiveEntries(file1Path);
+    const entries2 = listArchiveEntries(file2Path);
+    ({ changes: fileChanges, added, removed, modified, unchanged } = diffArchiveEntries(entries1, entries2));
+  }
+
+  const summary: ComparisonSummary = {
+    file1Path,
+    file2Path,
+    file1Name: path.basename(file1Path),
+    file2Name: path.basename(file2Path),
+    file1Size: file1Stat.size,
+    file2Size: file2Stat.size,
+    file1Hash,
+    file2Hash,
+    isIdentical,
+    isArchive: archiveMode,
+    added,
+    removed,
+    modified,
+    unchanged,
+    totalFiles1: removed + modified + unchanged,
+    totalFiles2: added + modified + unchanged,
+    sizeDelta: file2Stat.size - file1Stat.size,
+    sizeDeltaPercent: file1Stat.size > 0 ? Math.round(((file2Stat.size - file1Stat.size) / file1Stat.size) * 10000) / 100 : 0,
+  };
+
+  const knowledgeGraph = buildKnowledgeGraph(summary, fileChanges, binaryDiff);
+
+  return { summary, binaryDiff, fileChanges, knowledgeGraph, generatedAt: new Date().toISOString() };
+}

--- a/src/lib/knowledge-graph.ts
+++ b/src/lib/knowledge-graph.ts
@@ -1,0 +1,140 @@
+import type { ComparisonSummary, FileChange, BinaryDiff, ChangeType } from './binary-compare';
+
+export interface KGNode {
+  id: string;
+  label: string;
+  type: 'version' | 'file' | 'module' | 'metric';
+  group: string;
+  properties: Record<string, unknown>;
+}
+
+export interface KGEdge {
+  id: string;
+  source: string;
+  target: string;
+  relation: 'changed_to' | 'contains' | 'added_in' | 'removed_in' | 'modified_in' | 'has_metric' | 'belongs_to';
+  weight?: number;
+  properties?: Record<string, unknown>;
+}
+
+export interface KnowledgeGraph {
+  nodes: KGNode[];
+  edges: KGEdge[];
+  metadata: {
+    totalNodes: number;
+    totalEdges: number;
+    changeBreakdown: Record<ChangeType, number>;
+    generatedAt: string;
+  };
+}
+
+export function buildKnowledgeGraph(
+  summary: ComparisonSummary,
+  fileChanges: FileChange[],
+  binaryDiff: BinaryDiff,
+): KnowledgeGraph {
+  const nodes: KGNode[] = [];
+  const edges: KGEdge[] = [];
+  const seenModules = new Set<string>();
+
+  const v1Id = 'version:file1';
+  const v2Id = 'version:file2';
+  const metricId = 'metric:comparison';
+
+  nodes.push(
+    {
+      id: v1Id,
+      label: summary.file1Name,
+      type: 'version',
+      group: 'v1',
+      properties: { path: summary.file1Path, size: summary.file1Size, hash: summary.file1Hash.slice(0, 8) },
+    },
+    {
+      id: v2Id,
+      label: summary.file2Name,
+      type: 'version',
+      group: 'v2',
+      properties: { path: summary.file2Path, size: summary.file2Size, hash: summary.file2Hash.slice(0, 8) },
+    },
+    {
+      id: metricId,
+      label: 'Comparison Metrics',
+      type: 'metric',
+      group: 'metric',
+      properties: {
+        similarity: `${binaryDiff.similarity}%`,
+        sizeDelta: binaryDiff.sizeDelta,
+        sizeDeltaPercent: `${summary.sizeDeltaPercent}%`,
+        isIdentical: summary.isIdentical,
+        added: summary.added,
+        removed: summary.removed,
+        modified: summary.modified,
+        unchanged: summary.unchanged,
+        diffRegions: binaryDiff.diffRegions.length,
+      },
+    },
+  );
+
+  edges.push(
+    { id: 'e:v1-v2', source: v1Id, target: v2Id, relation: 'changed_to', weight: binaryDiff.similarity / 100, properties: { similarity: binaryDiff.similarity } },
+    { id: 'e:v1-metric', source: v1Id, target: metricId, relation: 'has_metric' },
+    { id: 'e:v2-metric', source: v2Id, target: metricId, relation: 'has_metric' },
+  );
+
+  // Only include meaningful (non-unchanged) file nodes, capped at 100 to keep graph manageable
+  const significant = fileChanges.filter(c => c.changeType !== 'unchanged').slice(0, 100);
+
+  for (const change of significant) {
+    const nodeId = `file:${change.path}`;
+    const label = change.path.split('/').pop() ?? change.path;
+
+    nodes.push({
+      id: nodeId,
+      label,
+      type: 'file',
+      group: change.changeType,
+      properties: {
+        path: change.path,
+        changeType: change.changeType,
+        sizeDelta: change.sizeDelta,
+        beforeSize: change.before?.uncompressedSize,
+        afterSize: change.after?.uncompressedSize,
+        crcChanged: change.crcChanged,
+      },
+    });
+
+    const relationMap: Record<string, KGEdge['relation']> = {
+      added: 'added_in',
+      removed: 'removed_in',
+      modified: 'modified_in',
+    };
+
+    const vSource = change.changeType === 'added' ? v2Id : v1Id;
+    edges.push({ id: `e:${change.changeType}:${change.path}`, source: vSource, target: nodeId, relation: relationMap[change.changeType] ?? 'contains' });
+
+    // Module grouping by directory
+    const parts = change.path.split('/');
+    if (parts.length > 1) {
+      const dir = parts.slice(0, -1).join('/');
+      const moduleId = `module:${dir}`;
+      if (!seenModules.has(moduleId)) {
+        seenModules.add(moduleId);
+        nodes.push({ id: moduleId, label: dir, type: 'module', group: 'module', properties: { directory: dir } });
+      }
+      edges.push({ id: `e:mod:${change.path}`, source: moduleId, target: nodeId, relation: 'belongs_to' });
+    }
+  }
+
+  const changeBreakdown: Record<ChangeType, number> = {
+    added: summary.added,
+    removed: summary.removed,
+    modified: summary.modified,
+    unchanged: summary.unchanged,
+  };
+
+  return {
+    nodes,
+    edges,
+    metadata: { totalNodes: nodes.length, totalEdges: edges.length, changeBreakdown, generatedAt: new Date().toISOString() },
+  };
+}

--- a/wrappers/linux/ipaship-cli.sh
+++ b/wrappers/linux/ipaship-cli.sh
@@ -1,12 +1,180 @@
 #!/bin/bash
-# Linux Bash wrapper for ipaship.com
-FILE_PATH=$1
-API_KEY=$2
+# ipaShip CLI — Linux/macOS wrapper
+# Supports: audit <file> and compare --file <f1> --file <f2>
 
-if [ -z "$FILE_PATH" ]; then
-    echo "Usage: $0 <file-path> [api-key]"
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+COMMAND="${1:-}"
+
+usage() {
+  cat <<'EOF'
+
+  ipaShip CLI
+
+  Commands:
+    audit   <file-path> [api-key]     Audit an IPA/APK file via ipaship.com
+    compare --file <f1> --file <f2>   Binary compare two files (Beyond-Compare style)
+
+  Compare options:
+    --format  text|json               Output format (default: text)
+    --output  <file>                  Write result to file
+
+  Examples:
+    ipaship-cli.sh audit MyApp.ipa sk-abc123
+    ipaship-cli.sh compare --file app-1.0.0.ipa --file app-1.0.1.ipa
+    ipaship-cli.sh compare --file v1.apk --file v2.apk --format json --output diff.json
+
+EOF
+}
+
+# ─── Audit ───────────────────────────────────────────────────────────────────
+
+cmd_audit() {
+  local file_path="${1:-}"
+  local api_key="${2:-}"
+
+  if [ -z "$file_path" ]; then
+    echo "Usage: $0 audit <file-path> [api-key]" >&2
     exit 1
-fi
+  fi
 
-echo "Auditing $FILE_PATH via ipaship.com..."
-# curl -X POST https://ipaship.com/api/audit -F "file=@$FILE_PATH" -H "Authorization: Bearer $API_KEY"
+  if [ ! -f "$file_path" ]; then
+    echo "Error: file not found: $file_path" >&2
+    exit 1
+  fi
+
+  echo "Auditing $file_path via ipaship.com..."
+  # curl -X POST https://ipaship.com/api/audit -F "file=@$file_path" -H "Authorization: Bearer $api_key"
+}
+
+# ─── Compare (pure bash, no external deps) ───────────────────────────────────
+
+cmd_compare() {
+  local files=()
+  local format="text"
+  local output=""
+
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --file)    files+=("$2"); shift 2 ;;
+      --format)  format="$2";  shift 2 ;;
+      --output)  output="$2";  shift 2 ;;
+      --help|-h) usage; exit 0 ;;
+      *) shift ;;
+    esac
+  done
+
+  if [ ${#files[@]} -lt 2 ]; then
+    echo "Error: provide --file twice." >&2
+    usage
+    exit 1
+  fi
+
+  local f1="${files[0]}"
+  local f2="${files[1]}"
+
+  for f in "$f1" "$f2"; do
+    if [ ! -f "$f" ]; then
+      echo "Error: file not found: $f" >&2
+      exit 1
+    fi
+  done
+
+  # ── Prefer Python wrapper if available ──────────────────────────────────────
+  local py_compare="$SCRIPT_DIR/../python/ipaship_compare.py"
+  if command -v python3 &>/dev/null && [ -f "$py_compare" ]; then
+    python3 "$py_compare" --file "$f1" --file "$f2" --format "$format" ${output:+--output "$output"}
+    return 0
+  fi
+
+  # ── Prefer Node.js wrapper if available ─────────────────────────────────────
+  local node_compare="$SCRIPT_DIR/../npm/compare.js"
+  if command -v node &>/dev/null && [ -f "$node_compare" ]; then
+    node "$node_compare" compare --file "$f1" --file "$f2" --format "$format" ${output:+--output "$output"}
+    return 0
+  fi
+
+  # ── Pure bash fallback ───────────────────────────────────────────────────────
+  echo ""
+  echo "  ipaShip Binary Compare"
+  echo "  ────────────────────────────────────────────────────────────"
+
+  local name1; name1=$(basename "$f1")
+  local name2; name2=$(basename "$f2")
+  local size1; size1=$(stat -c%s "$f1" 2>/dev/null || stat -f%z "$f1")
+  local size2; size2=$(stat -c%s "$f2" 2>/dev/null || stat -f%z "$f2")
+  local delta=$(( size2 - size1 ))
+
+  echo "  File 1 : $name1  ($size1 bytes)"
+  echo "  File 2 : $name2  ($size2 bytes)"
+  echo "  Delta  : ${delta:+}$delta bytes"
+  echo "  ────────────────────────────────────────────────────────────"
+
+  # Hash comparison
+  local hash1 hash2
+  if command -v sha256sum &>/dev/null; then
+    hash1=$(sha256sum "$f1" | awk '{print $1}')
+    hash2=$(sha256sum "$f2" | awk '{print $1}')
+  elif command -v shasum &>/dev/null; then
+    hash1=$(shasum -a 256 "$f1" | awk '{print $1}')
+    hash2=$(shasum -a 256 "$f2" | awk '{print $1}')
+  else
+    hash1="unavailable"
+    hash2="unavailable"
+  fi
+
+  if [ "$hash1" = "$hash2" ]; then
+    echo "  Identical  : YES"
+  else
+    echo "  Identical  : NO"
+    echo "  Hash 1     : ${hash1:0:16}..."
+    echo "  Hash 2     : ${hash2:0:16}..."
+  fi
+
+  # Archive comparison (IPA/APK/ZIP)
+  local ext1="${f1##*.}"
+  if [[ "$ext1" =~ ^(ipa|apk|zip|jar|aab)$ ]] && command -v unzip &>/dev/null; then
+    echo "  ────────────────────────────────────────────────────────────"
+    echo "  Archive Contents"
+
+    local tmp1; tmp1=$(mktemp)
+    local tmp2; tmp2=$(mktemp)
+    unzip -v "$f1" 2>/dev/null | awk '/^[[:space:]]*[0-9]/{print $NF}' | sort > "$tmp1"
+    unzip -v "$f2" 2>/dev/null | awk '/^[[:space:]]*[0-9]/{print $NF}' | sort > "$tmp2"
+
+    local added; added=$(comm -13 "$tmp1" "$tmp2" | wc -l | tr -d ' ')
+    local removed; removed=$(comm -23 "$tmp1" "$tmp2" | wc -l | tr -d ' ')
+    local common; common=$(comm -12 "$tmp1" "$tmp2" | wc -l | tr -d ' ')
+
+    echo "  Added   : $added"
+    echo "  Removed : $removed"
+    echo "  Common  : $common"
+
+    if [ "$added" -gt 0 ]; then
+      echo "  -- Added files --"
+      comm -13 "$tmp1" "$tmp2" | head -20 | while read -r line; do echo "    [+] $line"; done
+    fi
+    if [ "$removed" -gt 0 ]; then
+      echo "  -- Removed files --"
+      comm -23 "$tmp1" "$tmp2" | head -20 | while read -r line; do echo "    [-] $line"; done
+    fi
+
+    rm -f "$tmp1" "$tmp2"
+  fi
+
+  echo ""
+}
+
+# ─── Main Dispatch ───────────────────────────────────────────────────────────
+
+case "$COMMAND" in
+  audit)   shift; cmd_audit "$@" ;;
+  compare) shift; cmd_compare "$@" ;;
+  --help|-h|help) usage ;;
+  *)
+    echo "Unknown command: '$COMMAND'" >&2
+    usage
+    exit 1
+    ;;
+esac

--- a/wrappers/npm/compare.js
+++ b/wrappers/npm/compare.js
@@ -1,0 +1,316 @@
+#!/usr/bin/env node
+'use strict';
+
+/**
+ * ipaShip Binary Compare CLI
+ * Usage: ipaship compare --file <path1> --file <path2> [--format json|text] [--output <file>]
+ */
+
+const fs = require('fs');
+const crypto = require('crypto');
+const path = require('path');
+const { spawnSync } = require('child_process');
+
+// ─── Utilities ───────────────────────────────────────────────────────────────
+
+function hashFile(filePath) {
+  return crypto.createHash('sha256').update(fs.readFileSync(filePath)).digest('hex');
+}
+
+function isArchive(filePath) {
+  return ['.ipa', '.apk', '.zip', '.jar', '.aab'].includes(path.extname(filePath).toLowerCase());
+}
+
+function fmtBytes(n) {
+  if (Math.abs(n) < 1024) return `${n} B`;
+  if (Math.abs(n) < 1024 ** 2) return `${(n / 1024).toFixed(1)} KB`;
+  return `${(n / 1024 ** 2).toFixed(2)} MB`;
+}
+
+function fmtSign(n) {
+  return n > 0 ? `+${fmtBytes(n)}` : fmtBytes(n);
+}
+
+// ─── Archive Listing ─────────────────────────────────────────────────────────
+
+function listArchive(filePath) {
+  const r = spawnSync('unzip', ['-v', filePath], { encoding: 'utf8', maxBuffer: 64 * 1024 * 1024 });
+  if (r.error || r.status !== 0) return [];
+
+  const entries = [];
+  for (const line of r.stdout.split('\n')) {
+    const m = line.match(/^\s*(\d+)\s+(\S+)\s+(\d+)\s+\S+\s+\S+\s+\S+\s+([0-9a-fA-F]{8})\s+(.+)$/);
+    if (!m) continue;
+    const p = m[5].trim();
+    if (p.endsWith('/')) continue;
+    entries.push({ path: p, uncompressedSize: +m[1], compressedSize: +m[3], method: m[2], crc32: m[4].toLowerCase() });
+  }
+  return entries;
+}
+
+// ─── Binary Diff ─────────────────────────────────────────────────────────────
+
+function binaryDiff(f1, f2) {
+  const b1 = fs.readFileSync(f1);
+  const b2 = fs.readFileSync(f2);
+  const identical = b1.equals(b2);
+
+  if (identical) {
+    return { file1Size: b1.length, file2Size: b2.length, sizeDelta: 0, sizeDeltaPercent: 0, similarity: 100, totalBytesCompared: b1.length, diffBytes: 0, diffRegions: [], isIdentical: true };
+  }
+
+  const MAX = 10 * 1024 * 1024;
+  const len = Math.min(b1.length, b2.length, MAX);
+  let diffBytes = 0;
+  const regions = [];
+  let inDiff = false, start = 0;
+
+  for (let i = 0; i < len; i++) {
+    if (b1[i] !== b2[i]) {
+      diffBytes++;
+      if (!inDiff) { inDiff = true; start = i; }
+    } else if (inDiff) {
+      inDiff = false;
+      if (regions.length < 100) regions.push({ offset: start, length: i - start, hexOffset: `0x${start.toString(16).toUpperCase()}` });
+    }
+  }
+  if (inDiff && regions.length < 100) regions.push({ offset: start, length: len - start, hexOffset: `0x${start.toString(16).toUpperCase()}` });
+
+  const similarity = len > 0 ? Math.round(((len - diffBytes) / len) * 10000) / 100 : 0;
+  const sizeDelta = b2.length - b1.length;
+  return {
+    file1Size: b1.length, file2Size: b2.length,
+    sizeDelta, sizeDeltaPercent: b1.length > 0 ? Math.round((sizeDelta / b1.length) * 10000) / 100 : 0,
+    similarity, totalBytesCompared: len, diffBytes, diffRegions: regions, isIdentical: false,
+  };
+}
+
+// ─── Archive Diff ────────────────────────────────────────────────────────────
+
+function diffArchives(entries1, entries2) {
+  const m1 = new Map(entries1.map(e => [e.path, e]));
+  const m2 = new Map(entries2.map(e => [e.path, e]));
+  const changes = [];
+  let added = 0, removed = 0, modified = 0, unchanged = 0;
+
+  for (const [p, e] of m2) {
+    if (!m1.has(p)) { changes.push({ path: p, changeType: 'added', after: e, sizeDelta: e.uncompressedSize, crcChanged: true }); added++; }
+  }
+  for (const [p, e] of m1) {
+    if (!m2.has(p)) { changes.push({ path: p, changeType: 'removed', before: e, sizeDelta: -e.uncompressedSize, crcChanged: true }); removed++; }
+  }
+  for (const [p, e1] of m1) {
+    const e2 = m2.get(p);
+    if (!e2) continue;
+    if (e1.crc32 !== e2.crc32 || e1.uncompressedSize !== e2.uncompressedSize) {
+      changes.push({ path: p, changeType: 'modified', before: e1, after: e2, sizeDelta: e2.uncompressedSize - e1.uncompressedSize, crcChanged: e1.crc32 !== e2.crc32 });
+      modified++;
+    } else {
+      changes.push({ path: p, changeType: 'unchanged', before: e1, after: e2, sizeDelta: 0, crcChanged: false });
+      unchanged++;
+    }
+  }
+
+  const order = { added: 0, removed: 1, modified: 2, unchanged: 3 };
+  changes.sort((a, b) => order[a.changeType] - order[b.changeType]);
+  return { changes, added, removed, modified, unchanged };
+}
+
+// ─── Knowledge Graph ─────────────────────────────────────────────────────────
+
+function buildKnowledgeGraph(summary, fileChanges, diff) {
+  const nodes = [], edges = [];
+  const seenModules = new Set();
+
+  nodes.push(
+    { id: 'v1', label: summary.file1Name, type: 'version', group: 'v1', properties: { path: summary.file1Path, size: summary.file1Size, hash: summary.file1Hash.slice(0, 8) } },
+    { id: 'v2', label: summary.file2Name, type: 'version', group: 'v2', properties: { path: summary.file2Path, size: summary.file2Size, hash: summary.file2Hash.slice(0, 8) } },
+    { id: 'metric', label: 'Metrics', type: 'metric', group: 'metric', properties: { similarity: `${diff.similarity}%`, sizeDelta: diff.sizeDelta, added: summary.added, removed: summary.removed, modified: summary.modified } },
+  );
+
+  edges.push(
+    { id: 'e:v1-v2', source: 'v1', target: 'v2', relation: 'changed_to', weight: diff.similarity / 100 },
+    { id: 'e:v1-m', source: 'v1', target: 'metric', relation: 'has_metric' },
+    { id: 'e:v2-m', source: 'v2', target: 'metric', relation: 'has_metric' },
+  );
+
+  const significant = fileChanges.filter(c => c.changeType !== 'unchanged').slice(0, 100);
+  for (const c of significant) {
+    const nid = `file:${c.path}`;
+    nodes.push({ id: nid, label: c.path.split('/').pop() || c.path, type: 'file', group: c.changeType, properties: { path: c.path, changeType: c.changeType, sizeDelta: c.sizeDelta } });
+    const src = c.changeType === 'added' ? 'v2' : 'v1';
+    const rel = c.changeType === 'added' ? 'added_in' : c.changeType === 'removed' ? 'removed_in' : 'modified_in';
+    edges.push({ id: `e:${c.changeType}:${c.path}`, source: src, target: nid, relation: rel });
+    const parts = c.path.split('/');
+    if (parts.length > 1) {
+      const dir = parts.slice(0, -1).join('/');
+      const mid = `module:${dir}`;
+      if (!seenModules.has(mid)) { seenModules.add(mid); nodes.push({ id: mid, label: dir, type: 'module', group: 'module', properties: { directory: dir } }); }
+      edges.push({ id: `e:mod:${c.path}`, source: mid, target: nid, relation: 'belongs_to' });
+    }
+  }
+
+  return { nodes, edges, metadata: { totalNodes: nodes.length, totalEdges: edges.length, generatedAt: new Date().toISOString() } };
+}
+
+// ─── Text Renderer ───────────────────────────────────────────────────────────
+
+function renderText(result) {
+  const { summary: s, binaryDiff: d, fileChanges, knowledgeGraph: kg } = result;
+  const line = '─'.repeat(60);
+  const lines = [
+    '',
+    '  ipaShip Binary Compare',
+    line,
+    `  File 1 : ${s.file1Name}  (${fmtBytes(s.file1Size)})`,
+    `  File 2 : ${s.file2Name}  (${fmtBytes(s.file2Size)})`,
+    `  Delta  : ${fmtSign(s.sizeDelta)} (${s.sizeDeltaPercent > 0 ? '+' : ''}${s.sizeDeltaPercent}%)`,
+    line,
+    `  Identical  : ${s.isIdentical ? 'YES' : 'NO'}`,
+    `  Similarity : ${d.similarity}%`,
+    `  Bytes diff : ${d.diffBytes.toLocaleString()} / ${d.totalBytesCompared.toLocaleString()} compared`,
+    `  Diff regions (capped at 100): ${d.diffRegions.length}`,
+    '',
+  ];
+
+  if (s.isArchive) {
+    lines.push(
+      `  Archive Contents`,
+      line,
+      `  Files in v1 : ${s.totalFiles1}`,
+      `  Files in v2 : ${s.totalFiles2}`,
+      `  Added       : ${s.added}`,
+      `  Removed     : ${s.removed}`,
+      `  Modified    : ${s.modified}`,
+      `  Unchanged   : ${s.unchanged}`,
+      '',
+    );
+
+    const relevant = fileChanges.filter(c => c.changeType !== 'unchanged');
+    if (relevant.length > 0) {
+      lines.push(`  Changed Files (${relevant.length})`, line);
+      for (const c of relevant.slice(0, 200)) {
+        const icon = c.changeType === 'added' ? '[+]' : c.changeType === 'removed' ? '[-]' : '[~]';
+        const delta = c.sizeDelta !== 0 ? `  ${fmtSign(c.sizeDelta)}` : '';
+        lines.push(`  ${icon} ${c.path}${delta}`);
+      }
+      if (relevant.length > 200) lines.push(`  ... and ${relevant.length - 200} more`);
+      lines.push('');
+    }
+  }
+
+  lines.push(
+    `  Knowledge Graph`,
+    line,
+    `  Nodes : ${kg.nodes.length}  (versions, files, modules, metrics)`,
+    `  Edges : ${kg.edges.length}  (relationships)`,
+    '',
+    `  Generated : ${result.generatedAt}`,
+    '',
+  );
+
+  return lines.join('\n');
+}
+
+// ─── CLI Entry ───────────────────────────────────────────────────────────────
+
+function parseArgs(argv) {
+  const args = argv.slice(2);
+  const files = [];
+  let format = 'text';
+  let output = null;
+
+  for (let i = 0; i < args.length; i++) {
+    if (args[i] === 'compare') continue;
+    if (args[i] === '--file' && args[i + 1]) { files.push(args[++i]); continue; }
+    if (args[i] === '--format' && args[i + 1]) { format = args[++i]; continue; }
+    if (args[i] === '--output' && args[i + 1]) { output = args[++i]; continue; }
+    if (args[i] === '--help' || args[i] === '-h') return { help: true };
+  }
+  return { files, format, output };
+}
+
+function printHelp() {
+  console.log(`
+  ipaShip Binary Compare
+
+  Usage:
+    ipaship compare --file <path1> --file <path2> [options]
+
+  Options:
+    --file <path>      File to compare (provide twice)
+    --format text|json Output format (default: text)
+    --output <file>    Write result to file instead of stdout
+    --help             Show this help
+
+  Examples:
+    ipaship compare --file app-1.0.0.ipa --file app-1.0.1.ipa
+    ipaship compare --file v1.apk --file v2.apk --format json --output diff.json
+`);
+}
+
+function main() {
+  const opts = parseArgs(process.argv);
+
+  if (opts.help) { printHelp(); process.exit(0); }
+
+  const { files, format, output } = opts;
+
+  if (!files || files.length < 2) {
+    console.error('Error: provide exactly two --file arguments.\nRun with --help for usage.');
+    process.exit(1);
+  }
+
+  const [f1, f2] = files;
+
+  for (const f of [f1, f2]) {
+    if (!fs.existsSync(f)) { console.error(`Error: file not found: ${f}`); process.exit(1); }
+  }
+
+  try {
+    const file1Stat = fs.statSync(f1);
+    const file2Stat = fs.statSync(f2);
+    const file1Hash = hashFile(f1);
+    const file2Hash = hashFile(f2);
+    const archiveMode = isArchive(f1) || isArchive(f2);
+    const diff = binaryDiff(f1, f2);
+
+    let added = 0, removed = 0, modified = 0, unchanged = 0, fileChanges = [];
+    if (archiveMode) {
+      const e1 = listArchive(f1);
+      const e2 = listArchive(f2);
+      ({ changes: fileChanges, added, removed, modified, unchanged } = diffArchives(e1, e2));
+    }
+
+    const summary = {
+      file1Path: f1, file2Path: f2,
+      file1Name: path.basename(f1), file2Name: path.basename(f2),
+      file1Size: file1Stat.size, file2Size: file2Stat.size,
+      file1Hash, file2Hash,
+      isIdentical: file1Hash === file2Hash,
+      isArchive: archiveMode,
+      added, removed, modified, unchanged,
+      totalFiles1: removed + modified + unchanged,
+      totalFiles2: added + modified + unchanged,
+      sizeDelta: file2Stat.size - file1Stat.size,
+      sizeDeltaPercent: file1Stat.size > 0 ? Math.round(((file2Stat.size - file1Stat.size) / file1Stat.size) * 10000) / 100 : 0,
+    };
+
+    const knowledgeGraph = buildKnowledgeGraph(summary, fileChanges, diff);
+    const result = { summary, binaryDiff: diff, fileChanges, knowledgeGraph, generatedAt: new Date().toISOString() };
+
+    const rendered = format === 'json' ? JSON.stringify(result, null, 2) : renderText(result);
+
+    if (output) {
+      fs.writeFileSync(output, rendered, 'utf8');
+      console.log(`Result written to ${output}`);
+    } else {
+      console.log(rendered);
+    }
+  } catch (err) {
+    console.error(`Error: ${err.message}`);
+    process.exit(1);
+  }
+}
+
+main();

--- a/wrappers/npm/package.json
+++ b/wrappers/npm/package.json
@@ -1,11 +1,18 @@
 {
   "name": "ipaship-wrapper",
   "version": "1.0.0",
-  "description": "ipaShip Node.js wrapper",
+  "description": "ipaShip Node.js wrapper with binary compare CLI",
   "main": "index.js",
+  "bin": {
+    "ipaship": "compare.js"
+  },
   "scripts": {
+    "compare": "node compare.js compare",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "author": "async-atharv",
-  "license": "Polyform Noncommercial License 1.0.0"
+  "license": "Polyform Noncommercial License 1.0.0",
+  "engines": {
+    "node": ">=18"
+  }
 }

--- a/wrappers/python/ipaship_compare.py
+++ b/wrappers/python/ipaship_compare.py
@@ -1,0 +1,450 @@
+#!/usr/bin/env python3
+"""
+ipaShip Binary Compare Module
+Compares two binary/archive files (IPA, APK, ZIP, etc.) and produces a
+structured diff report with a knowledge graph.
+
+CLI:  python ipaship_compare.py --file path1 --file path2 [--format text|json] [--output file]
+API:  from ipaship_compare import compare_files
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import re
+import subprocess
+import sys
+from dataclasses import asdict, dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Optional
+
+ARCHIVE_EXTENSIONS = {".ipa", ".apk", ".zip", ".jar", ".aab", ".xcarchive"}
+MAX_BINARY_BYTES = 10 * 1024 * 1024  # 10 MB
+MAX_DIFF_REGIONS = 100
+
+
+# ─── Data Classes ────────────────────────────────────────────────────────────
+
+
+@dataclass
+class ArchiveEntry:
+    path: str
+    uncompressed_size: int
+    compressed_size: int
+    crc32: str
+    method: str
+
+
+@dataclass
+class DiffRegion:
+    offset: int
+    length: int
+    hex_offset: str
+
+
+@dataclass
+class BinaryDiff:
+    file1_size: int
+    file2_size: int
+    size_delta: int
+    size_delta_percent: float
+    similarity: float
+    total_bytes_compared: int
+    diff_bytes: int
+    diff_regions: list[DiffRegion]
+    is_identical: bool
+
+
+@dataclass
+class FileChange:
+    path: str
+    change_type: str  # added | removed | modified | unchanged
+    size_delta: int
+    crc_changed: bool
+    before: Optional[ArchiveEntry] = None
+    after: Optional[ArchiveEntry] = None
+
+
+@dataclass
+class ComparisonSummary:
+    file1_path: str
+    file2_path: str
+    file1_name: str
+    file2_name: str
+    file1_size: int
+    file2_size: int
+    file1_hash: str
+    file2_hash: str
+    is_identical: bool
+    is_archive: bool
+    added: int
+    removed: int
+    modified: int
+    unchanged: int
+    total_files1: int
+    total_files2: int
+    size_delta: int
+    size_delta_percent: float
+
+
+@dataclass
+class KGNode:
+    id: str
+    label: str
+    type: str
+    group: str
+    properties: dict = field(default_factory=dict)
+
+
+@dataclass
+class KGEdge:
+    id: str
+    source: str
+    target: str
+    relation: str
+    weight: Optional[float] = None
+    properties: dict = field(default_factory=dict)
+
+
+@dataclass
+class KnowledgeGraph:
+    nodes: list[KGNode]
+    edges: list[KGEdge]
+    metadata: dict = field(default_factory=dict)
+
+
+@dataclass
+class CompareResult:
+    summary: ComparisonSummary
+    binary_diff: BinaryDiff
+    file_changes: list[FileChange]
+    knowledge_graph: KnowledgeGraph
+    generated_at: str
+
+
+# ─── Helpers ─────────────────────────────────────────────────────────────────
+
+
+def hash_file(path: str) -> str:
+    h = hashlib.sha256()
+    with open(path, "rb") as f:
+        for chunk in iter(lambda: f.read(65536), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def is_archive(path: str) -> bool:
+    return Path(path).suffix.lower() in ARCHIVE_EXTENSIONS
+
+
+def fmt_bytes(n: int) -> str:
+    sign = "+" if n > 0 else ""
+    a = abs(n)
+    if a < 1024:
+        return f"{sign}{n} B"
+    if a < 1024**2:
+        return f"{sign}{n / 1024:.1f} KB"
+    return f"{sign}{n / 1024 ** 2:.2f} MB"
+
+
+# ─── Archive Listing ─────────────────────────────────────────────────────────
+
+
+def list_archive(file_path: str) -> list[ArchiveEntry]:
+    try:
+        result = subprocess.run(
+            ["unzip", "-v", file_path],
+            capture_output=True, text=True, timeout=60,
+        )
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        return []
+
+    entries: list[ArchiveEntry] = []
+    pattern = re.compile(
+        r"^\s*(\d+)\s+(\S+)\s+(\d+)\s+\S+\s+\S+\s+\S+\s+([0-9a-fA-F]{8})\s+(.+)$"
+    )
+    for line in result.stdout.splitlines():
+        m = pattern.match(line)
+        if not m:
+            continue
+        p = m.group(5).strip()
+        if p.endswith("/"):
+            continue
+        entries.append(ArchiveEntry(
+            path=p,
+            uncompressed_size=int(m.group(1)),
+            compressed_size=int(m.group(3)),
+            method=m.group(2),
+            crc32=m.group(4).lower(),
+        ))
+    return entries
+
+
+# ─── Binary Diff ─────────────────────────────────────────────────────────────
+
+
+def compute_binary_diff(f1: str, f2: str) -> BinaryDiff:
+    data1 = open(f1, "rb").read()
+    data2 = open(f2, "rb").read()
+    identical = data1 == data2
+    size1, size2 = len(data1), len(data2)
+    delta = size2 - size1
+    delta_pct = round((delta / size1) * 100, 2) if size1 else 0.0
+
+    if identical:
+        return BinaryDiff(size1, size2, 0, 0.0, 100.0, size1, 0, [], True)
+
+    compare_len = min(size1, size2, MAX_BINARY_BYTES)
+    diff_bytes = 0
+    regions: list[DiffRegion] = []
+    in_diff = False
+    start = 0
+
+    for i in range(compare_len):
+        if data1[i] != data2[i]:
+            diff_bytes += 1
+            if not in_diff:
+                in_diff = True
+                start = i
+        elif in_diff:
+            in_diff = False
+            if len(regions) < MAX_DIFF_REGIONS:
+                regions.append(DiffRegion(start, i - start, f"0x{start:X}"))
+
+    if in_diff and len(regions) < MAX_DIFF_REGIONS:
+        regions.append(DiffRegion(start, compare_len - start, f"0x{start:X}"))
+
+    similarity = round(((compare_len - diff_bytes) / compare_len) * 100, 2) if compare_len else 0.0
+
+    return BinaryDiff(size1, size2, delta, delta_pct, similarity, compare_len, diff_bytes, regions, False)
+
+
+# ─── Archive Diff ─────────────────────────────────────────────────────────────
+
+
+def diff_archives(entries1: list[ArchiveEntry], entries2: list[ArchiveEntry]):
+    map1 = {e.path: e for e in entries1}
+    map2 = {e.path: e for e in entries2}
+    changes: list[FileChange] = []
+    added = removed = modified = unchanged = 0
+
+    for p, e in map2.items():
+        if p not in map1:
+            changes.append(FileChange(p, "added", e.uncompressed_size, True, after=e))
+            added += 1
+
+    for p, e in map1.items():
+        if p not in map2:
+            changes.append(FileChange(p, "removed", -e.uncompressed_size, True, before=e))
+            removed += 1
+
+    for p, e1 in map1.items():
+        e2 = map2.get(p)
+        if not e2:
+            continue
+        crc_changed = e1.crc32 != e2.crc32
+        if crc_changed or e1.uncompressed_size != e2.uncompressed_size:
+            changes.append(FileChange(p, "modified", e2.uncompressed_size - e1.uncompressed_size, crc_changed, e1, e2))
+            modified += 1
+        else:
+            changes.append(FileChange(p, "unchanged", 0, False, e1, e2))
+            unchanged += 1
+
+    order = {"added": 0, "removed": 1, "modified": 2, "unchanged": 3}
+    changes.sort(key=lambda c: order[c.change_type])
+    return changes, added, removed, modified, unchanged
+
+
+# ─── Knowledge Graph ─────────────────────────────────────────────────────────
+
+
+def build_knowledge_graph(summary: ComparisonSummary, file_changes: list[FileChange], diff: BinaryDiff) -> KnowledgeGraph:
+    nodes: list[KGNode] = []
+    edges: list[KGEdge] = []
+    seen_modules: set[str] = set()
+
+    nodes += [
+        KGNode("v1", summary.file1_name, "version", "v1", {"path": summary.file1_path, "size": summary.file1_size, "hash": summary.file1_hash[:8]}),
+        KGNode("v2", summary.file2_name, "version", "v2", {"path": summary.file2_path, "size": summary.file2_size, "hash": summary.file2_hash[:8]}),
+        KGNode("metric", "Metrics", "metric", "metric", {"similarity": f"{diff.similarity}%", "size_delta": diff.size_delta, "added": summary.added, "removed": summary.removed, "modified": summary.modified}),
+    ]
+    edges += [
+        KGEdge("e:v1-v2", "v1", "v2", "changed_to", diff.similarity / 100),
+        KGEdge("e:v1-m", "v1", "metric", "has_metric"),
+        KGEdge("e:v2-m", "v2", "metric", "has_metric"),
+    ]
+
+    relation_map = {"added": "added_in", "removed": "removed_in", "modified": "modified_in"}
+    significant = [c for c in file_changes if c.change_type != "unchanged"][:100]
+
+    for c in significant:
+        nid = f"file:{c.path}"
+        label = c.path.split("/")[-1]
+        nodes.append(KGNode(nid, label, "file", c.change_type, {"path": c.path, "change_type": c.change_type, "size_delta": c.size_delta}))
+        src = "v2" if c.change_type == "added" else "v1"
+        rel = relation_map.get(c.change_type, "contains")
+        edges.append(KGEdge(f"e:{c.change_type}:{c.path}", src, nid, rel))
+
+        parts = c.path.split("/")
+        if len(parts) > 1:
+            directory = "/".join(parts[:-1])
+            mid = f"module:{directory}"
+            if mid not in seen_modules:
+                seen_modules.add(mid)
+                nodes.append(KGNode(mid, directory, "module", "module", {"directory": directory}))
+            edges.append(KGEdge(f"e:mod:{c.path}", mid, nid, "belongs_to"))
+
+    return KnowledgeGraph(nodes, edges, {"total_nodes": len(nodes), "total_edges": len(edges), "generated_at": datetime.now(timezone.utc).isoformat()})
+
+
+# ─── Core API ────────────────────────────────────────────────────────────────
+
+
+def compare_files(file1: str, file2: str) -> CompareResult:
+    for f in (file1, file2):
+        if not os.path.isfile(f):
+            raise FileNotFoundError(f"File not found: {f}")
+
+    size1 = os.path.getsize(file1)
+    size2 = os.path.getsize(file2)
+    hash1 = hash_file(file1)
+    hash2 = hash_file(file2)
+    archive_mode = is_archive(file1) or is_archive(file2)
+    diff = compute_binary_diff(file1, file2)
+
+    added = removed = modified = unchanged = 0
+    file_changes: list[FileChange] = []
+
+    if archive_mode:
+        e1 = list_archive(file1)
+        e2 = list_archive(file2)
+        file_changes, added, removed, modified, unchanged = diff_archives(e1, e2)
+
+    summary = ComparisonSummary(
+        file1_path=file1, file2_path=file2,
+        file1_name=Path(file1).name, file2_name=Path(file2).name,
+        file1_size=size1, file2_size=size2,
+        file1_hash=hash1, file2_hash=hash2,
+        is_identical=hash1 == hash2,
+        is_archive=archive_mode,
+        added=added, removed=removed, modified=modified, unchanged=unchanged,
+        total_files1=removed + modified + unchanged,
+        total_files2=added + modified + unchanged,
+        size_delta=size2 - size1,
+        size_delta_percent=round(((size2 - size1) / size1) * 100, 2) if size1 else 0.0,
+    )
+
+    kg = build_knowledge_graph(summary, file_changes, diff)
+    return CompareResult(summary, diff, file_changes, kg, datetime.now(timezone.utc).isoformat())
+
+
+# ─── Text Renderer ───────────────────────────────────────────────────────────
+
+
+def render_text(result: CompareResult) -> str:
+    s, d, kg = result.summary, result.binary_diff, result.knowledge_graph
+    sep = "─" * 60
+    out = [
+        "",
+        "  ipaShip Binary Compare",
+        sep,
+        f"  File 1 : {s.file1_name}  ({fmt_bytes(s.file1_size)})",
+        f"  File 2 : {s.file2_name}  ({fmt_bytes(s.file2_size)})",
+        f"  Delta  : {fmt_bytes(s.size_delta)} ({'+' if s.size_delta_percent > 0 else ''}{s.size_delta_percent}%)",
+        sep,
+        f"  Identical  : {'YES' if s.is_identical else 'NO'}",
+        f"  Similarity : {d.similarity}%",
+        f"  Bytes diff : {d.diff_bytes:,} / {d.total_bytes_compared:,} compared",
+        f"  Diff regions (capped at 100): {len(d.diff_regions)}",
+        "",
+    ]
+
+    if s.is_archive:
+        out += [
+            "  Archive Contents",
+            sep,
+            f"  Files in v1 : {s.total_files1}",
+            f"  Files in v2 : {s.total_files2}",
+            f"  Added       : {s.added}",
+            f"  Removed     : {s.removed}",
+            f"  Modified    : {s.modified}",
+            f"  Unchanged   : {s.unchanged}",
+            "",
+        ]
+        relevant = [c for c in result.file_changes if c.change_type != "unchanged"]
+        if relevant:
+            out.append(f"  Changed Files ({len(relevant)})")
+            out.append(sep)
+            icons = {"added": "[+]", "removed": "[-]", "modified": "[~]"}
+            for c in relevant[:200]:
+                delta = f"  {fmt_bytes(c.size_delta)}" if c.size_delta else ""
+                out.append(f"  {icons[c.change_type]} {c.path}{delta}")
+            if len(relevant) > 200:
+                out.append(f"  ... and {len(relevant) - 200} more")
+            out.append("")
+
+    out += [
+        "  Knowledge Graph",
+        sep,
+        f"  Nodes : {len(kg.nodes)}  (versions, files, modules, metrics)",
+        f"  Edges : {len(kg.edges)}  (relationships)",
+        "",
+        f"  Generated : {result.generated_at}",
+        "",
+    ]
+    return "\n".join(out)
+
+
+# ─── Serialization ───────────────────────────────────────────────────────────
+
+
+def result_to_dict(result: CompareResult) -> dict:
+    def convert(obj):
+        if hasattr(obj, "__dataclass_fields__"):
+            return {k: convert(v) for k, v in asdict(obj).items()}
+        if isinstance(obj, list):
+            return [convert(i) for i in obj]
+        return obj
+    return convert(result)
+
+
+# ─── CLI ─────────────────────────────────────────────────────────────────────
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        prog="ipaship compare",
+        description="ipaShip Binary Compare — compare two IPA/APK/binary files",
+    )
+    parser.add_argument("--file", dest="files", action="append", required=True, metavar="PATH",
+                        help="File path (provide twice)")
+    parser.add_argument("--format", choices=["text", "json"], default="text",
+                        help="Output format (default: text)")
+    parser.add_argument("--output", metavar="FILE",
+                        help="Write output to file instead of stdout")
+    args = parser.parse_args()
+
+    if len(args.files) < 2:
+        parser.error("Provide --file twice: --file path1 --file path2")
+
+    try:
+        result = compare_files(args.files[0], args.files[1])
+    except Exception as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        sys.exit(1)
+
+    rendered = json.dumps(result_to_dict(result), indent=2) if args.format == "json" else render_text(result)
+
+    if args.output:
+        Path(args.output).write_text(rendered, encoding="utf-8")
+        print(f"Result written to {args.output}")
+    else:
+        print(rendered)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Fixes #97

## Changes
---

**Résumé des changements :**

Trois nouvelles couches ont été ajoutées pour implémenter la fonctionnalité "Beyond Compare like" :

1. **Module TypeScript core** (`src/lib/binary-compare.ts` + `src/lib/knowledge-graph.ts`) : comparaison byte-level avec score de similarité, analyse CRC32 des archives (IPA/APK/ZIP) pour détecter ajouts/suppressions/modifications sans extraction complète, et construction d'un knowledge graph (nœuds : versions, fichiers, modules, métriques ; arêtes : changed_to, added_in, removed_in, modified_in, belongs_to). Exposé via une API Next.js (`src/app/api/compare/route.ts`, méthodes GET et POST).

2. **CLI Node.js autonome** (`wrappers/npm/compare.js`) : implémentation standalone (zéro dépendance externe) qui supporte exactement la syntaxe requise `ipaship compa

## Test Results
Erreur tests: [Errno 2] No such file or directory: 'npm'

---
*Implemented by [Mira](https://github.com/Mira-Mjodheim)*