### PR TITLE
fix: sanitize upload file paths

### DIFF
--- a/src/app/api/audit/route.ts
+++ b/src/app/api/audit/route.ts
@@ -50,6 +50,22 @@ const SKIP_DIRS = new Set([
 const MAX_FILE_SIZE = 50_000; // 50KB per individual source file
 const MAX_TOTAL_CONTENT = 350_000; // 350KB total context (roughly ~90k tokens max)
 
+function sanitizeUploadFileName(filename: string): string {
+  const baseName = path.basename(filename || 'upload.ipa');
+  const safeName = baseName.replace(/[^a-zA-Z0-9._-]/g, '_').slice(0, 255);
+  return safeName || 'upload.ipa';
+}
+
+function resolveUploadedFilePath(fileId: string, fileName: string): string {
+  const safeFileId = path.basename(fileId);
+  if (!safeFileId.startsWith('gracias-upload-') || safeFileId !== fileId) {
+    throw new Error('Invalid uploaded file reference');
+  }
+
+  const uploadDir = path.join(os.tmpdir(), safeFileId);
+  return path.join(uploadDir, sanitizeUploadFileName(fileName));
+}
+
 function getClientKey(req: NextRequest): string {
   const forwarded = req.headers.get('x-forwarded-for');
   if (forwarded) {
@@ -128,7 +144,7 @@ function parseMultipartStream(
         return;
       }
 
-      fileName = info.filename || 'upload.ipa';
+      fileName = sanitizeUploadFileName(info.filename);
       filePath = path.join(tempDir, fileName);
       fileReceived = true;
 
@@ -179,7 +195,7 @@ function parseMultipartStream(
         return;
       }
       if (!fileReceived && fileId) {
-        filePath = path.join(os.tmpdir(), fileId, fileName);
+        filePath = resolveUploadedFilePath(fileId, fileName);
         fileReceived = true;
         writeFinished = true;
       }

--- a/src/app/api/upload/route.ts
+++ b/src/app/api/upload/route.ts
@@ -11,6 +11,12 @@ export const maxDuration = 300;
 const MAX_UPLOAD_SIZE = 150 * 1024 * 1024;
 const UPLOAD_TEMP_TTL_MS = 30 * 60 * 1000; // 30 minutes
 
+function sanitizeUploadFileName(filename: string): string {
+  const baseName = path.basename(filename || 'upload.ipa');
+  const safeName = baseName.replace(/[^a-zA-Z0-9._-]/g, '_').slice(0, 255);
+  return safeName || 'upload.ipa';
+}
+
 export async function POST(req: NextRequest) {
   let tempDir: string | null = null;
   
@@ -68,7 +74,7 @@ export async function POST(req: NextRequest) {
           return;
         }
 
-        fileName = info.filename || 'upload.ipa';
+        fileName = sanitizeUploadFileName(info.filename);
         filePath = path.join(tempDir!, fileName);
         fileReceived = true;
 


### PR DESCRIPTION
## Summary
- sanitize uploaded filenames before writing multipart uploads to disk
- constrain stored upload references to the expected temp upload directory prefix
- reuse sanitized filenames when auditing previously uploaded files

## Why
This fixes a minor upload handling bug where client-supplied multipart filenames and follow-up audit fields could influence server-side temp paths. It is a narrow hardening fix suitable for the minor-bugs bounty work in #86.

## Verification
- npm run build
- npx tsc --noEmit

Fixes part of #86