### PR TITLE
Add Gracias AI SVG logo pack

### DIFF
--- a/logo/README.md
+++ b/logo/README.md
@@ -1,0 +1,23 @@
+# Gracias AI Logo Pack
+
+This submission adds an original SVG logo package for the Gracias AI App Store Auditor bounty.
+
+## Files
+
+- `logomark.svg` - icon-only mark for light or neutral backgrounds
+- `logomark-dark.svg` - icon-only mark tuned for dark backgrounds
+- `wordmark.svg` - logomark plus "Gracias AI" for light backgrounds
+- `wordmark-dark.svg` - logomark plus "Gracias AI" for dark backgrounds
+- `preview.svg` - review sheet showing the logo on light and dark surfaces
+
+## Design Rationale
+
+The mark combines a rounded app-tile silhouette, an audit shield, a compliance check, and connected neural nodes. The rounded tile references modern iOS product language without using Apple trademarks, while the shield/check structure signals security, policy compliance, and trust. The neural nodes keep the AI/LLM meaning visible at small sizes.
+
+## Palette
+
+- Purple: `#a855f7`
+- Blue: `#3b82f6`
+- White: `#ffffff`
+
+The wordmark uses system UI font fallbacks so it renders close to Apple platform typography while remaining portable in SVG.

--- a/logo/logomark-dark.svg
+++ b/logo/logomark-dark.svg
@@ -1,0 +1,34 @@
+<svg width="256" height="256" viewBox="0 0 256 256" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="title desc">
+  <title id="title">Gracias AI logomark dark variant</title>
+  <desc id="desc">Dark-background variant of the Gracias AI audit shield logomark.</desc>
+  <defs>
+    <linearGradient id="tileDark" x1="36" y1="24" x2="220" y2="232" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#a855f7"/>
+      <stop offset="0.58" stop-color="#725cf4"/>
+      <stop offset="1" stop-color="#3b82f6"/>
+    </linearGradient>
+    <linearGradient id="shieldDark" x1="82" y1="64" x2="174" y2="180" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#ffffff"/>
+      <stop offset="1" stop-color="#dbeafe"/>
+    </linearGradient>
+    <filter id="glow" x="16" y="12" width="224" height="232" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+      <feDropShadow dx="0" dy="0" stdDeviation="12" flood-color="#7c5cf4" flood-opacity="0.45"/>
+      <feDropShadow dx="0" dy="12" stdDeviation="18" flood-color="#030712" flood-opacity="0.35"/>
+    </filter>
+  </defs>
+  <rect x="28" y="24" width="200" height="208" rx="48" fill="url(#tileDark)" filter="url(#glow)"/>
+  <rect x="34" y="30" width="188" height="196" rx="42" stroke="#ffffff" stroke-opacity="0.2" stroke-width="2"/>
+  <path d="M128 60L178 79V121C178 153 158 181 128 194C98 181 78 153 78 121V79L128 60Z" fill="url(#shieldDark)" fill-opacity="0.98"/>
+  <path d="M128 74L164 88V120C164 145 150 166 128 178C106 166 92 145 92 120V88L128 74Z" fill="#0b1220" fill-opacity="0.09"/>
+  <path d="M104 124L121 141L153 105" stroke="#ffffff" stroke-width="12" stroke-linecap="round" stroke-linejoin="round"/>
+  <path d="M104 124L121 141L153 105" stroke="#3b82f6" stroke-width="7" stroke-linecap="round" stroke-linejoin="round"/>
+  <path d="M104 91L126 107L151 91" stroke="#a855f7" stroke-width="6" stroke-linecap="round" stroke-linejoin="round"/>
+  <path d="M104 91L101 119M151 91L156 119M126 107V137" stroke="#3b82f6" stroke-width="5" stroke-linecap="round" stroke-linejoin="round" opacity="0.82"/>
+  <circle cx="104" cy="91" r="7" fill="#a855f7" stroke="#ffffff" stroke-width="4"/>
+  <circle cx="151" cy="91" r="7" fill="#3b82f6" stroke="#ffffff" stroke-width="4"/>
+  <circle cx="126" cy="107" r="7" fill="#815df5" stroke="#ffffff" stroke-width="4"/>
+  <circle cx="101" cy="119" r="5" fill="#3b82f6"/>
+  <circle cx="156" cy="119" r="5" fill="#a855f7"/>
+  <circle cx="126" cy="137" r="5" fill="#3b82f6"/>
+  <path d="M64 55H82M55 64V82M174 199H192M201 174V192" stroke="#ffffff" stroke-width="7" stroke-linecap="round" opacity="0.8"/>
+</svg>

--- a/logo/logomark.svg
+++ b/logo/logomark.svg
@@ -1,0 +1,32 @@
+<svg width="256" height="256" viewBox="0 0 256 256" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="title desc">
+  <title id="title">Gracias AI logomark</title>
+  <desc id="desc">Rounded gradient app tile with an audit shield, neural nodes, and compliance checkmark.</desc>
+  <defs>
+    <linearGradient id="tile" x1="40" y1="28" x2="216" y2="228" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#a855f7"/>
+      <stop offset="0.56" stop-color="#7c5cf4"/>
+      <stop offset="1" stop-color="#3b82f6"/>
+    </linearGradient>
+    <linearGradient id="shield" x1="82" y1="64" x2="174" y2="180" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#ffffff"/>
+      <stop offset="1" stop-color="#eaf2ff"/>
+    </linearGradient>
+    <filter id="softShadow" x="28" y="24" width="208" height="216" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+      <feDropShadow dx="0" dy="12" stdDeviation="14" flood-color="#1f2a44" flood-opacity="0.18"/>
+    </filter>
+  </defs>
+  <rect x="28" y="24" width="200" height="208" rx="48" fill="url(#tile)" filter="url(#softShadow)"/>
+  <path d="M128 60L178 79V121C178 153 158 181 128 194C98 181 78 153 78 121V79L128 60Z" fill="url(#shield)" fill-opacity="0.96"/>
+  <path d="M128 74L164 88V120C164 145 150 166 128 178C106 166 92 145 92 120V88L128 74Z" fill="#0b1220" fill-opacity="0.08"/>
+  <path d="M104 124L121 141L153 105" stroke="#ffffff" stroke-width="12" stroke-linecap="round" stroke-linejoin="round"/>
+  <path d="M104 124L121 141L153 105" stroke="#3b82f6" stroke-width="7" stroke-linecap="round" stroke-linejoin="round"/>
+  <path d="M104 91L126 107L151 91" stroke="#a855f7" stroke-width="6" stroke-linecap="round" stroke-linejoin="round"/>
+  <path d="M104 91L101 119M151 91L156 119M126 107V137" stroke="#3b82f6" stroke-width="5" stroke-linecap="round" stroke-linejoin="round" opacity="0.78"/>
+  <circle cx="104" cy="91" r="7" fill="#a855f7" stroke="#ffffff" stroke-width="4"/>
+  <circle cx="151" cy="91" r="7" fill="#3b82f6" stroke="#ffffff" stroke-width="4"/>
+  <circle cx="126" cy="107" r="7" fill="#815df5" stroke="#ffffff" stroke-width="4"/>
+  <circle cx="101" cy="119" r="5" fill="#3b82f6"/>
+  <circle cx="156" cy="119" r="5" fill="#a855f7"/>
+  <circle cx="126" cy="137" r="5" fill="#3b82f6"/>
+  <path d="M64 55H82M55 64V82M174 199H192M201 174V192" stroke="#ffffff" stroke-width="7" stroke-linecap="round" opacity="0.72"/>
+</svg>

--- a/logo/preview.svg
+++ b/logo/preview.svg
@@ -1,0 +1,49 @@
+<svg width="1120" height="720" viewBox="0 0 1120 720" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="title desc">
+  <title id="title">Gracias AI logo preview</title>
+  <desc id="desc">Preview sheet showing the Gracias AI logo package on light and dark backgrounds.</desc>
+  <defs>
+    <linearGradient id="tile" x1="174" y1="106" x2="326" y2="274" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#a855f7"/>
+      <stop offset="0.56" stop-color="#7c5cf4"/>
+      <stop offset="1" stop-color="#3b82f6"/>
+    </linearGradient>
+    <linearGradient id="accent" x1="447" y1="157" x2="534" y2="197" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#a855f7"/>
+      <stop offset="1" stop-color="#3b82f6"/>
+    </linearGradient>
+  </defs>
+  <rect width="1120" height="720" rx="36" fill="#f8fafc"/>
+  <rect x="56" y="56" width="1008" height="286" rx="28" fill="#ffffff" stroke="#e4e7ec"/>
+  <rect x="56" y="378" width="1008" height="286" rx="28" fill="#0b1220"/>
+  <g transform="translate(128 102)">
+    <rect x="18" y="14" width="126" height="132" rx="32" fill="url(#tile)"/>
+    <path d="M81 36L113 48V75C113 96 100 114 81 123C62 114 49 96 49 75V48L81 36Z" fill="#ffffff" fill-opacity="0.97"/>
+    <path d="M66 77L77 88L98 65" stroke="#ffffff" stroke-width="8" stroke-linecap="round" stroke-linejoin="round"/>
+    <path d="M66 77L77 88L98 65" stroke="#3b82f6" stroke-width="5" stroke-linecap="round" stroke-linejoin="round"/>
+    <path d="M65 56L80 66L96 56" stroke="#a855f7" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
+    <path d="M65 56L63 73M96 56L99 73M80 66V84" stroke="#3b82f6" stroke-width="3.5" stroke-linecap="round" stroke-linejoin="round" opacity="0.82"/>
+    <circle cx="65" cy="56" r="4.8" fill="#a855f7" stroke="#ffffff" stroke-width="2.5"/>
+    <circle cx="96" cy="56" r="4.8" fill="#3b82f6" stroke="#ffffff" stroke-width="2.5"/>
+    <circle cx="80" cy="66" r="4.8" fill="#815df5" stroke="#ffffff" stroke-width="2.5"/>
+    <text x="172" y="79" fill="#101828" font-family="-apple-system, BlinkMacSystemFont, 'SF Pro Display', 'Segoe UI', sans-serif" font-size="46" font-weight="760" letter-spacing="-1.6">Gracias</text>
+    <text x="338" y="79" fill="url(#accent)" font-family="-apple-system, BlinkMacSystemFont, 'SF Pro Display', 'Segoe UI', sans-serif" font-size="46" font-weight="760" letter-spacing="-1.6">AI</text>
+    <text x="174" y="108" fill="#475467" font-family="-apple-system, BlinkMacSystemFont, 'SF Pro Text', 'Segoe UI', sans-serif" font-size="15" font-weight="560" letter-spacing="2.1">APP STORE COMPLIANCE AUDITOR</text>
+  </g>
+  <g transform="translate(128 424)">
+    <rect x="18" y="14" width="126" height="132" rx="32" fill="url(#tile)"/>
+    <rect x="22" y="18" width="118" height="124" rx="28" stroke="#ffffff" stroke-opacity="0.2" stroke-width="1.5"/>
+    <path d="M81 36L113 48V75C113 96 100 114 81 123C62 114 49 96 49 75V48L81 36Z" fill="#ffffff" fill-opacity="0.98"/>
+    <path d="M66 77L77 88L98 65" stroke="#ffffff" stroke-width="8" stroke-linecap="round" stroke-linejoin="round"/>
+    <path d="M66 77L77 88L98 65" stroke="#3b82f6" stroke-width="5" stroke-linecap="round" stroke-linejoin="round"/>
+    <path d="M65 56L80 66L96 56" stroke="#a855f7" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
+    <path d="M65 56L63 73M96 56L99 73M80 66V84" stroke="#3b82f6" stroke-width="3.5" stroke-linecap="round" stroke-linejoin="round" opacity="0.84"/>
+    <circle cx="65" cy="56" r="4.8" fill="#a855f7" stroke="#ffffff" stroke-width="2.5"/>
+    <circle cx="96" cy="56" r="4.8" fill="#3b82f6" stroke="#ffffff" stroke-width="2.5"/>
+    <circle cx="80" cy="66" r="4.8" fill="#815df5" stroke="#ffffff" stroke-width="2.5"/>
+    <text x="172" y="79" fill="#ffffff" font-family="-apple-system, BlinkMacSystemFont, 'SF Pro Display', 'Segoe UI', sans-serif" font-size="46" font-weight="760" letter-spacing="-1.6">Gracias</text>
+    <text x="338" y="79" fill="#8ab8ff" font-family="-apple-system, BlinkMacSystemFont, 'SF Pro Display', 'Segoe UI', sans-serif" font-size="46" font-weight="760" letter-spacing="-1.6">AI</text>
+    <text x="174" y="108" fill="#cbd5e1" font-family="-apple-system, BlinkMacSystemFont, 'SF Pro Text', 'Segoe UI', sans-serif" font-size="15" font-weight="560" letter-spacing="2.1">APP STORE COMPLIANCE AUDITOR</text>
+  </g>
+  <text x="128" y="306" fill="#667085" font-family="-apple-system, BlinkMacSystemFont, 'SF Pro Text', 'Segoe UI', sans-serif" font-size="16" font-weight="560">Light background</text>
+  <text x="128" y="628" fill="#94a3b8" font-family="-apple-system, BlinkMacSystemFont, 'SF Pro Text', 'Segoe UI', sans-serif" font-size="16" font-weight="560">Dark background</text>
+</svg>

--- a/logo/wordmark-dark.svg
+++ b/logo/wordmark-dark.svg
@@ -1,0 +1,31 @@
+<svg width="560" height="160" viewBox="0 0 560 160" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="title desc">
+  <title id="title">Gracias AI wordmark dark variant</title>
+  <desc id="desc">Gracias AI wordmark with the audit shield logomark for dark backgrounds.</desc>
+  <defs>
+    <linearGradient id="tileDark" x1="21" y1="16" x2="123" y2="136" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#a855f7"/>
+      <stop offset="0.56" stop-color="#7c5cf4"/>
+      <stop offset="1" stop-color="#3b82f6"/>
+    </linearGradient>
+    <linearGradient id="textAccentDark" x1="250" y1="52" x2="337" y2="92" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#c084fc"/>
+      <stop offset="1" stop-color="#60a5fa"/>
+    </linearGradient>
+    <filter id="markGlow" x="6" y="2" width="150" height="156" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+      <feDropShadow dx="0" dy="0" stdDeviation="8" flood-color="#7c5cf4" flood-opacity="0.36"/>
+    </filter>
+  </defs>
+  <rect x="18" y="14" width="126" height="132" rx="32" fill="url(#tileDark)" filter="url(#markGlow)"/>
+  <rect x="22" y="18" width="118" height="124" rx="28" stroke="#ffffff" stroke-opacity="0.2" stroke-width="1.5"/>
+  <path d="M81 36L113 48V75C113 96 100 114 81 123C62 114 49 96 49 75V48L81 36Z" fill="#ffffff" fill-opacity="0.98"/>
+  <path d="M66 77L77 88L98 65" stroke="#ffffff" stroke-width="8" stroke-linecap="round" stroke-linejoin="round"/>
+  <path d="M66 77L77 88L98 65" stroke="#3b82f6" stroke-width="5" stroke-linecap="round" stroke-linejoin="round"/>
+  <path d="M65 56L80 66L96 56" stroke="#a855f7" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
+  <path d="M65 56L63 73M96 56L99 73M80 66V84" stroke="#3b82f6" stroke-width="3.5" stroke-linecap="round" stroke-linejoin="round" opacity="0.84"/>
+  <circle cx="65" cy="56" r="4.8" fill="#a855f7" stroke="#ffffff" stroke-width="2.5"/>
+  <circle cx="96" cy="56" r="4.8" fill="#3b82f6" stroke="#ffffff" stroke-width="2.5"/>
+  <circle cx="80" cy="66" r="4.8" fill="#815df5" stroke="#ffffff" stroke-width="2.5"/>
+  <text x="172" y="79" fill="#ffffff" font-family="-apple-system, BlinkMacSystemFont, 'SF Pro Display', 'Segoe UI', sans-serif" font-size="46" font-weight="760" letter-spacing="-1.6">Gracias</text>
+  <text x="338" y="79" fill="url(#textAccentDark)" font-family="-apple-system, BlinkMacSystemFont, 'SF Pro Display', 'Segoe UI', sans-serif" font-size="46" font-weight="760" letter-spacing="-1.6">AI</text>
+  <text x="174" y="108" fill="#cbd5e1" font-family="-apple-system, BlinkMacSystemFont, 'SF Pro Text', 'Segoe UI', sans-serif" font-size="15" font-weight="560" letter-spacing="2.1">APP STORE COMPLIANCE AUDITOR</text>
+</svg>

--- a/logo/wordmark.svg
+++ b/logo/wordmark.svg
@@ -1,0 +1,27 @@
+<svg width="560" height="160" viewBox="0 0 560 160" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="title desc">
+  <title id="title">Gracias AI wordmark</title>
+  <desc id="desc">Gracias AI wordmark with the audit shield logomark for light backgrounds.</desc>
+  <defs>
+    <linearGradient id="tile" x1="21" y1="16" x2="123" y2="136" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#a855f7"/>
+      <stop offset="0.56" stop-color="#7c5cf4"/>
+      <stop offset="1" stop-color="#3b82f6"/>
+    </linearGradient>
+    <linearGradient id="textAccent" x1="250" y1="52" x2="337" y2="92" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#a855f7"/>
+      <stop offset="1" stop-color="#3b82f6"/>
+    </linearGradient>
+  </defs>
+  <rect x="18" y="14" width="126" height="132" rx="32" fill="url(#tile)"/>
+  <path d="M81 36L113 48V75C113 96 100 114 81 123C62 114 49 96 49 75V48L81 36Z" fill="#ffffff" fill-opacity="0.97"/>
+  <path d="M66 77L77 88L98 65" stroke="#ffffff" stroke-width="8" stroke-linecap="round" stroke-linejoin="round"/>
+  <path d="M66 77L77 88L98 65" stroke="#3b82f6" stroke-width="5" stroke-linecap="round" stroke-linejoin="round"/>
+  <path d="M65 56L80 66L96 56" stroke="#a855f7" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
+  <path d="M65 56L63 73M96 56L99 73M80 66V84" stroke="#3b82f6" stroke-width="3.5" stroke-linecap="round" stroke-linejoin="round" opacity="0.82"/>
+  <circle cx="65" cy="56" r="4.8" fill="#a855f7" stroke="#ffffff" stroke-width="2.5"/>
+  <circle cx="96" cy="56" r="4.8" fill="#3b82f6" stroke="#ffffff" stroke-width="2.5"/>
+  <circle cx="80" cy="66" r="4.8" fill="#815df5" stroke="#ffffff" stroke-width="2.5"/>
+  <text x="172" y="79" fill="#101828" font-family="-apple-system, BlinkMacSystemFont, 'SF Pro Display', 'Segoe UI', sans-serif" font-size="46" font-weight="760" letter-spacing="-1.6">Gracias</text>
+  <text x="338" y="79" fill="url(#textAccent)" font-family="-apple-system, BlinkMacSystemFont, 'SF Pro Display', 'Segoe UI', sans-serif" font-size="46" font-weight="760" letter-spacing="-1.6">AI</text>
+  <text x="174" y="108" fill="#475467" font-family="-apple-system, BlinkMacSystemFont, 'SF Pro Text', 'Segoe UI', sans-serif" font-size="15" font-weight="560" letter-spacing="2.1">APP STORE COMPLIANCE AUDITOR</text>
+</svg>


### PR DESCRIPTION
## Summary

Bounty submission for #2. This adds an original SVG logo package for Gracias AI:

- `logo/logomark.svg`
- `logo/logomark-dark.svg`
- `logo/wordmark.svg`
- `logo/wordmark-dark.svg`
- `logo/preview.svg`
- `logo/README.md`

## Design Notes

The mark uses a rounded app-tile silhouette, audit shield, compliance check, and connected neural nodes. It references modern iOS product language through shape and proportion without using Apple trademark artwork. The package keeps the requested purple/blue/white palette and includes light/dark wordmark variants.

## Validation

- Parsed all SVG files as XML successfully
- Ran `git diff --check` successfully
- Rendered `logo/preview.svg` locally for visual review

References #2