### PR TITLE
Add binary compare CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,14 @@ cd wrappers/npm && npm install
 node index.js
 ```
 
+**Binary Compare CLI**
+```bash
+npm run compare -- --file /path/to/app-v1 --file /path/to/app-v2
+npm run compare -- --file /path/to/app-v1 --file /path/to/app-v2 --json
+```
+
+The compare command reports added, removed, and changed files with size and SHA-256 metadata. It works with files or directories, so versioned app exports can be compared before a knowledge graph layer consumes the diff.
+
 **Python**
 ```bash
 cd wrappers/python

--- a/bin/ipaship.js
+++ b/bin/ipaship.js
@@ -1,0 +1,99 @@
+#!/usr/bin/env node
+
+const {comparePaths} = require('../src/utils/binary-compare');
+
+function printHelp() {
+  console.log(`Usage:
+  ipaship compare --file <path1> --file <path2> [--json]
+
+Commands:
+  compare   Compare two files or directories and report added, removed, and changed files.
+
+Options:
+  --file    File or directory to compare. Pass exactly two.
+  --json    Print the full comparison result as JSON.
+  --help    Show this help message.`);
+}
+
+function parseArgs(argv) {
+  const args = {files: [], json: false, command: argv[2]};
+
+  for (let index = 3; index < argv.length; index += 1) {
+    const arg = argv[index];
+
+    if (arg === '--file') {
+      const value = argv[index + 1];
+      if (!value) {
+        throw new Error('--file requires a path');
+      }
+      args.files.push(value);
+      index += 1;
+      continue;
+    }
+
+    if (arg === '--json') {
+      args.json = true;
+      continue;
+    }
+
+    if (arg === '--help' || arg === '-h') {
+      args.help = true;
+      continue;
+    }
+
+    throw new Error(`Unknown argument: ${arg}`);
+  }
+
+  return args;
+}
+
+function printTextResult(result) {
+  const {summary} = result;
+  console.log(`Compared ${result.left.path} -> ${result.right.path}`);
+  console.log(`Added: ${summary.added}, removed: ${summary.removed}, changed: ${summary.changed}, unchanged: ${summary.unchanged}`);
+
+  for (const file of result.added) {
+    console.log(`+ ${file.path} (${file.size} bytes, ${file.sha256})`);
+  }
+
+  for (const file of result.removed) {
+    console.log(`- ${file.path} (${file.size} bytes, ${file.sha256})`);
+  }
+
+  for (const file of result.changed) {
+    console.log(`~ ${file.path} (${file.before.size} -> ${file.after.size} bytes)`);
+    console.log(`  before: ${file.before.sha256}`);
+    console.log(`  after:  ${file.after.sha256}`);
+  }
+}
+
+async function main() {
+  const args = parseArgs(process.argv);
+
+  if (args.help || !args.command) {
+    printHelp();
+    return;
+  }
+
+  if (args.command !== 'compare') {
+    throw new Error(`Unknown command: ${args.command}`);
+  }
+
+  if (args.files.length !== 2) {
+    throw new Error('compare requires exactly two --file paths');
+  }
+
+  const result = await comparePaths(args.files[0], args.files[1]);
+
+  if (args.json) {
+    console.log(JSON.stringify(result, null, 2));
+    return;
+  }
+
+  printTextResult(result);
+}
+
+main().catch((error) => {
+  console.error(error.message);
+  process.exitCode = 1;
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,9 @@
       "name": "ipaship",
       "version": "1.0.0",
       "license": "ISC",
+      "bin": {
+        "ipaship": "bin/ipaship.js"
+      },
       "dependencies": {
         "@clerk/nextjs": "^6.39.1",
         "busboy": "^1.6.0",

--- a/package.json
+++ b/package.json
@@ -2,12 +2,16 @@
   "name": "ipaship",
   "version": "1.0.0",
   "main": "index.js",
+  "bin": {
+    "ipaship": "./bin/ipaship.js"
+  },
   "engines": {
     "node": ">=20"
   },
   "scripts": {
     "dev": "next dev",
     "build": "next build",
+    "compare": "node bin/ipaship.js compare",
     "start": "next start -H 0.0.0.0 -p 8080"
   },
   "keywords": [],

--- a/src/utils/binary-compare.js
+++ b/src/utils/binary-compare.js
@@ -1,0 +1,135 @@
+const {createHash} = require('node:crypto');
+const fs = require('node:fs/promises');
+const path = require('node:path');
+
+async function statPath(targetPath) {
+  try {
+    return await fs.stat(targetPath);
+  } catch (error) {
+    if (error && error.code === 'ENOENT') {
+      throw new Error(`Path does not exist: ${targetPath}`);
+    }
+    throw error;
+  }
+}
+
+async function hashFile(filePath) {
+  const contents = await fs.readFile(filePath);
+  return createHash('sha256').update(contents).digest('hex');
+}
+
+async function describeFile(filePath, relativePath) {
+  const stats = await statPath(filePath);
+
+  return {
+    path: relativePath,
+    size: stats.size,
+    mode: stats.mode,
+    mtimeMs: Math.round(stats.mtimeMs),
+    sha256: await hashFile(filePath),
+  };
+}
+
+async function walkDirectory(rootPath, currentPath = rootPath) {
+  const entries = await fs.readdir(currentPath, {withFileTypes: true});
+  const files = [];
+
+  for (const entry of entries) {
+    const absolutePath = path.join(currentPath, entry.name);
+
+    if (entry.isDirectory()) {
+      files.push(...await walkDirectory(rootPath, absolutePath));
+      continue;
+    }
+
+    if (entry.isFile()) {
+      const relativePath = path.relative(rootPath, absolutePath).split(path.sep).join('/');
+      files.push(await describeFile(absolutePath, relativePath));
+    }
+  }
+
+  return files.sort((left, right) => left.path.localeCompare(right.path));
+}
+
+function indexByPath(files) {
+  return new Map(files.map((file) => [file.path, file]));
+}
+
+async function snapshot(targetPath) {
+  const absolutePath = path.resolve(targetPath);
+  const stats = await statPath(absolutePath);
+
+  if (stats.isDirectory()) {
+    return {
+      type: 'directory',
+      root: absolutePath,
+      files: await walkDirectory(absolutePath),
+    };
+  }
+
+  if (stats.isFile()) {
+    return {
+      type: 'file',
+      root: path.dirname(absolutePath),
+      files: [await describeFile(absolutePath, path.basename(absolutePath))],
+    };
+  }
+
+  throw new Error(`Only files and directories can be compared: ${targetPath}`);
+}
+
+async function comparePaths(leftPath, rightPath) {
+  const [left, right] = await Promise.all([snapshot(leftPath), snapshot(rightPath)]);
+
+  if (left.type === 'file' && right.type === 'file') {
+    left.files[0].path = 'file';
+    right.files[0].path = 'file';
+  }
+
+  const leftByPath = indexByPath(left.files);
+  const rightByPath = indexByPath(right.files);
+  const added = [];
+  const removed = [];
+  const changed = [];
+  const unchanged = [];
+
+  for (const [filePath, rightFile] of rightByPath) {
+    const leftFile = leftByPath.get(filePath);
+
+    if (!leftFile) {
+      added.push(rightFile);
+      continue;
+    }
+
+    if (leftFile.sha256 !== rightFile.sha256 || leftFile.size !== rightFile.size) {
+      changed.push({path: filePath, before: leftFile, after: rightFile});
+      continue;
+    }
+
+    unchanged.push(rightFile);
+  }
+
+  for (const [filePath, leftFile] of leftByPath) {
+    if (!rightByPath.has(filePath)) {
+      removed.push(leftFile);
+    }
+  }
+
+  return {
+    left: {path: path.resolve(leftPath), type: left.type, files: left.files.length},
+    right: {path: path.resolve(rightPath), type: right.type, files: right.files.length},
+    summary: {
+      added: added.length,
+      removed: removed.length,
+      changed: changed.length,
+      unchanged: unchanged.length,
+    },
+    added,
+    removed,
+    changed,
+  };
+}
+
+module.exports = {
+  comparePaths,
+};


### PR DESCRIPTION
## Summary
- adds a dependency-free binary comparison module for files and directories
- exposes `ipaship compare --file <path1> --file <path2>` via the package bin
- reports added, removed, changed, and unchanged files with size and SHA-256 metadata
- documents text and JSON compare usage in the README

## Verification
- `node bin/ipaship.js compare --file /private/tmp/ipaship-compare-left --file /private/tmp/ipaship-compare-right`
- `node bin/ipaship.js compare --file /private/tmp/ipaship-compare-left --file /private/tmp/ipaship-compare-right --json`
- `node bin/ipaship.js compare --file /private/tmp/ipaship-file-a.bin --file /private/tmp/ipaship-file-b.bin`
- `git diff --check`

## Note
I could not complete `npm ci` / `npm run build` locally because npm registry downloads repeatedly failed with `ECONNRESET` on `whatwg-url-14.2.0.tgz`. The CLI itself uses only Node built-ins and was smoke-tested directly.

Closes #97
