### PR TITLE
Fix NVIDIA and OpenAI API stream parsing and API key handling

### DIFF
--- a/src/app/api/audit/route.ts
+++ b/src/app/api/audit/route.ts
@@ -453,8 +453,8 @@ export async function POST(req: NextRequest) {
 
     // Stream-parse the multipart upload — writes file directly to disk
     // without ever loading the full file into memory
-    const { filePath, fileName, provider, model, context } = await parseMultipartStream(req, tempDir);
-    const resolvedApiKey = process.env.NVIDIA_KEY || process.env.NEXT_PUBLIC_API_KEY || '';
+    const { filePath, fileName, apiKey, provider, model, context } = await parseMultipartStream(req, tempDir);
+    const resolvedApiKey = apiKey || process.env.NVIDIA_KEY || process.env.NEXT_PUBLIC_API_KEY || '';
 
     if (!resolvedApiKey || !resolvedApiKey.trim()) {
       return NextResponse.json({ error: 'API key is required in environment variables' }, { status: 500 });
@@ -597,7 +597,7 @@ export async function POST(req: NextRequest) {
                 if (data === '[DONE]') continue;
                 try {
                   const parsed = JSON.parse(data);
-                  const textFragment = parsed.delta?.text || '';
+                  const textFragment = parsed.choices?.[0]?.delta?.content || parsed.delta?.text || '';
                   if (textFragment) {
                     controller.enqueue(encoder.encode(JSON.stringify({ type: 'content', text: textFragment }) + '\n'));
                   }


### PR DESCRIPTION
Fixes the issue where NVIDIA and OpenAI stream responses were parsed incorrectly due to assuming Anthropic's `delta.text` payload structure instead of `choices[0].delta.content`. Also fixes the issue where the `apiKey` extracted from the multipart stream was not being used to resolve the provider's API key. Closes #85 and addresses minor bugs in #86.