### PR TITLE
fix: deduplicate extensions, fix stars URL, assign fileId, null-safe body

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,6 @@
 {
   "name": "ipaship",
   "version": "1.0.0",
-  "main": "index.js",
   "engines": {
     "node": ">=20"
   },

--- a/src/app/api/audit/route.ts
+++ b/src/app/api/audit/route.ts
@@ -26,14 +26,19 @@ export const maxDuration = 300; // 5 minutes
 const MAX_UPLOAD_SIZE = 150 * 1024 * 1024; // 150MB hard limit
 
 const RELEVANT_EXTENSIONS = new Set([
-  '.swift', '.dart', '.m', '.h', '.mm',
+  // iOS
+  '.swift', '.m', '.h', '.mm',
   '.plist', '.storyboard', '.xib', '.pbxproj',
-  '.entitlements', '.json', '.xml', '.yaml', '.yml',
-  '.md', '.txt', '.strings', '.xcprivacy',
-  '.js', '.ts', '.tsx', '.jsx',
-  '.java', '.kt', '.xml', '.gradle', '.pro', // Android extensions
-  '.html', '.css',
+  '.entitlements', '.xcprivacy',
+  // Cross-platform
+  '.dart',
+  // Web / JS
+  '.js', '.ts', '.tsx', '.jsx', '.html', '.css',
+  // Android
   '.java', '.kt', '.gradle', '.pro', '.properties',
+  // Config / data
+  '.json', '.xml', '.yaml', '.yml',
+  '.md', '.txt', '.strings',
 ]);
 
 const SKIP_DIRS = new Set([
@@ -116,7 +121,7 @@ function parseMultipartStream(
     // Resolve only when both busboy is done AND the file has been fully written to disk
     const tryResolve = () => {
       if (busboyFinished && writeFinished && !rejected) {
-        resolve({ filePath, fileName, apiKey, provider, model, context });
+        resolve({ filePath, fileName, apiKey, provider, model, context, fileId: path.basename(tempDir) });
       }
     };
 

--- a/src/app/api/github-stars/route.ts
+++ b/src/app/api/github-stars/route.ts
@@ -8,7 +8,7 @@ const starsCache = new LRUCache<string, number>({
   ttl: 1000 * 60 * 5, // 5 minutes
 });
 
-const REPO = 'https://github.com/atharvnaik1/GraciasAi-Appstore-Policy-Auditor-Opensource';
+const REPO = 'atharvnaik1/ipaship-app-reviewer';
 const CACHE_KEY = 'stars';
 
 export async function GET() {

--- a/src/app/api/upload/route.ts
+++ b/src/app/api/upload/route.ts
@@ -20,7 +20,10 @@ export async function POST(req: NextRequest) {
     const contentType = req.headers.get('content-type') || '';
     
     // Convert Web ReadableStream to Node.js Readable
-    const reader = req.body!.getReader();
+    if (!req.body) {
+      return NextResponse.json({ error: 'Empty request body' }, { status: 400 });
+    }
+    const reader = req.body.getReader();
     const nodeStream = new Readable({
       async read() {
         try {


### PR DESCRIPTION
## Summary

Fixes several bugs found in the codebase (closes #86):

### 1. Duplicate extensions in `RELEVANT_EXTENSIONS` (`audit/route.ts`)
`.xml`, `.java`, `.kt`, `.gradle`, `.pro` were listed twice. Cleaned up and grouped by platform with comments for clarity.

### 2. Wrong repo URL in `github-stars/route.ts`
The `REPO` constant pointed to `GraciasAi-Appstore-Policy-Auditor-Opensource` (old/renamed repo name), causing the GitHub stars API to return 404. Fixed to `atharvnaik1/ipaship-app-reviewer`.

### 3. `fileId` never assigned in `audit/route.ts`
`fileId` was declared but never set in `parseMultipartStream`, unlike the upload route which correctly sets it to `path.basename(tempDir)`. Now consistent.

### 4. Null check on `req.body` in `upload/route.ts`
`req.body!.getReader()` used a non-null assertion but `req.body` can be null. Added a proper null check with a 400 response.

### 5. Orphan `main: "index.js"` in `package.json`
The file doesn't exist. This is a Next.js app, not a publishable npm module. Removed.

---

All fixes are minimal and non-breaking. No new dependencies added.