### PR TITLE
Fix BYOK provider API keys and streaming output

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3810,6 +3810,111 @@
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
       }
+    },
+    "node_modules/@next/swc-darwin-x64": {
+      "version": "15.5.13",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-15.5.13.tgz",
+      "integrity": "sha512-Ey3fuUeWDWtVdgiLHajk2aJ74Y8EWLeqvfwlkB5RvWsN7F1caQ6TjifsQzrAcOuNSnogGvFNYzjQlu7tu0kyWg==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-arm64-gnu": {
+      "version": "15.5.13",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-15.5.13.tgz",
+      "integrity": "sha512-aLtu/WxDeL3188qx3zyB3+iw8nAB9F+2Mhyz9nNZpzsREc2t8jQTuiWY4+mtOgWp1d+/Q4eXuy9m3dwh3n1IyQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-arm64-musl": {
+      "version": "15.5.13",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-15.5.13.tgz",
+      "integrity": "sha512-9VZ0OsVx9PEL72W50QD15iwSCF3GD/dwj42knfF5C4aiBPXr95etGIOGhb8rU7kpnzZuPNL81CY4vIyUKa2xvg==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-x64-gnu": {
+      "version": "15.5.13",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-15.5.13.tgz",
+      "integrity": "sha512-3knsu9H33e99ZfiWh0Bb04ymEO7YIiopOpXKX89ZZ/ER0iyfV1YLoJFxJJQNUD7OR8O7D7eiLI/TXPryPGv3+A==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-x64-musl": {
+      "version": "15.5.13",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-15.5.13.tgz",
+      "integrity": "sha512-AVPb6+QZ0pPanJFc1hpx81I5tTiBF4VITw5+PMaR1CrboAUUxtxn3IsV0h48xI7fzd6/zw9D9i6khRwME5NKUw==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-arm64-msvc": {
+      "version": "15.5.13",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-15.5.13.tgz",
+      "integrity": "sha512-FZ/HXuTxn+e5Lp6oRZMvHaMJx22gAySveJdJE0//91Nb9rMuh2ftgKlEwBFJxhkw5kAF/yIXz3iBf0tvDXRmCA==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-x64-msvc": {
+      "version": "15.5.13",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-15.5.13.tgz",
+      "integrity": "sha512-B5E82pX3VXu6Ib5mDuZEqGwT8asocZe3OMMnaM+Yfs0TRlmSQCBQUUXR9BkXQeGVboOWS1pTsRkS9wzFd8PABw==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
     }
   }
 }

--- a/src/app/api/audit/provider-config.test.mjs
+++ b/src/app/api/audit/provider-config.test.mjs
@@ -1,0 +1,41 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { extractStreamText, resolveProviderApiKey } from './provider-config.ts';
+
+test('resolveProviderApiKey prefers a submitted BYOK value over env fallbacks', () => {
+  const env = {
+    NVIDIA_API_KEY: 'env-nvidia-key',
+    ANTHROPIC_API_KEY: 'env-anthropic-key',
+  };
+
+  assert.equal(resolveProviderApiKey('nvidia', ' submitted-key ', env), 'submitted-key');
+  assert.equal(resolveProviderApiKey('anthropic', ' submitted-claude-key ', env), 'submitted-claude-key');
+});
+
+test('resolveProviderApiKey uses provider-specific environment fallbacks', () => {
+  const env = {
+    NVIDIA_KEY: 'env-nvidia-key',
+    CLAUDE_API_KEY: 'env-claude-key',
+    OPENAI_API_KEY: 'env-openai-key',
+    GEMINI_API_KEY: 'env-gemini-key',
+    OPENROUTER_API_KEY: 'env-openrouter-key',
+  };
+
+  assert.equal(resolveProviderApiKey('ipaship', '', env), 'env-nvidia-key');
+  assert.equal(resolveProviderApiKey('nvidia', '', env), 'env-nvidia-key');
+  assert.equal(resolveProviderApiKey('anthropic', '', env), 'env-claude-key');
+  assert.equal(resolveProviderApiKey('openai', '', env), 'env-openai-key');
+  assert.equal(resolveProviderApiKey('gemini', '', env), 'env-gemini-key');
+  assert.equal(resolveProviderApiKey('openrouter', '', env), 'env-openrouter-key');
+});
+
+test('extractStreamText supports Anthropic, OpenAI-compatible, NVIDIA, and Gemini chunks', () => {
+  assert.equal(extractStreamText({ delta: { text: 'claude' } }), 'claude');
+  assert.equal(extractStreamText({ choices: [{ delta: { content: 'openai' } }] }), 'openai');
+  assert.equal(extractStreamText({ choices: [{ text: 'legacy' }] }), 'legacy');
+  assert.equal(
+    extractStreamText({ candidates: [{ content: { parts: [{ text: 'gem' }, { text: 'ini' }] } }] }),
+    'gemini'
+  );
+});

--- a/src/app/api/audit/provider-config.ts
+++ b/src/app/api/audit/provider-config.ts
@@ -1,0 +1,83 @@
+export type AuditProvider =
+  | 'ipaship'
+  | 'nvidia'
+  | 'anthropic'
+  | 'openai'
+  | 'gemini'
+  | 'openrouter';
+
+export const VALID_PROVIDERS = new Set<AuditProvider>([
+  'ipaship',
+  'nvidia',
+  'anthropic',
+  'openai',
+  'gemini',
+  'openrouter',
+]);
+
+export function isValidProvider(provider: string): provider is AuditProvider {
+  return VALID_PROVIDERS.has(provider as AuditProvider);
+}
+
+const PROVIDER_ENV_KEYS: Record<AuditProvider, string[]> = {
+  ipaship: ['NVIDIA_API_KEY', 'NVIDIA_KEY', 'NEXT_PUBLIC_API_KEY'],
+  nvidia: ['NVIDIA_API_KEY', 'NVIDIA_KEY', 'NEXT_PUBLIC_API_KEY'],
+  anthropic: ['ANTHROPIC_API_KEY', 'CLAUDE_API_KEY', 'NEXT_PUBLIC_API_KEY'],
+  openai: ['OPENAI_API_KEY', 'NEXT_PUBLIC_API_KEY'],
+  gemini: ['GEMINI_API_KEY', 'GOOGLE_API_KEY', 'NEXT_PUBLIC_API_KEY'],
+  openrouter: ['OPENROUTER_API_KEY', 'NEXT_PUBLIC_API_KEY'],
+};
+
+export function resolveProviderApiKey(
+  provider: string,
+  submittedApiKey: string | undefined,
+  env: Record<string, string | undefined> = process.env
+): string {
+  const submitted = submittedApiKey?.trim();
+  if (submitted) return submitted;
+
+  const envKeys = PROVIDER_ENV_KEYS[provider as AuditProvider] || [];
+  for (const key of envKeys) {
+    const value = env[key]?.trim();
+    if (value) return value;
+  }
+
+  return '';
+}
+
+export function getProviderApiKeyError(provider: string): string {
+  switch (provider) {
+    case 'anthropic':
+      return 'Anthropic API key is required. Enter a Claude key or set ANTHROPIC_API_KEY/CLAUDE_API_KEY.';
+    case 'openai':
+      return 'OpenAI API key is required. Enter a key or set OPENAI_API_KEY.';
+    case 'gemini':
+      return 'Gemini API key is required. Enter a key or set GEMINI_API_KEY/GOOGLE_API_KEY.';
+    case 'openrouter':
+      return 'OpenRouter API key is required. Enter a key or set OPENROUTER_API_KEY.';
+    case 'nvidia':
+    case 'ipaship':
+    default:
+      return 'NVIDIA API key is required. Enter a key or set NVIDIA_API_KEY/NVIDIA_KEY.';
+  }
+}
+
+export function extractStreamText(parsed: any): string {
+  if (!parsed || typeof parsed !== 'object') return '';
+
+  const anthropicText = parsed.delta?.text;
+  if (typeof anthropicText === 'string') return anthropicText;
+
+  const choice = parsed.choices?.[0];
+  const openAiCompatibleText = choice?.delta?.content ?? choice?.message?.content ?? choice?.text;
+  if (typeof openAiCompatibleText === 'string') return openAiCompatibleText;
+
+  const geminiParts = parsed.candidates?.[0]?.content?.parts;
+  if (Array.isArray(geminiParts)) {
+    return geminiParts
+      .map((part) => (typeof part?.text === 'string' ? part.text : ''))
+      .join('');
+  }
+
+  return '';
+}

--- a/src/app/api/audit/route.ts
+++ b/src/app/api/audit/route.ts
@@ -8,6 +8,12 @@ import { Readable } from 'stream';
 import Busboy from 'busboy';
 import { LRUCache } from 'lru-cache';
 import { buildRetrievedContext, type SourceFile } from '../../../utils/audit-retrieval';
+import {
+  extractStreamText,
+  getProviderApiKeyError,
+  isValidProvider,
+  resolveProviderApiKey,
+} from './provider-config';
 
 const execFileAsync = promisify(execFile);
 
@@ -453,12 +459,7 @@ export async function POST(req: NextRequest) {
 
     // Stream-parse the multipart upload — writes file directly to disk
     // without ever loading the full file into memory
-    const { filePath, fileName, provider, model, context } = await parseMultipartStream(req, tempDir);
-    const resolvedApiKey = process.env.NVIDIA_KEY || process.env.NEXT_PUBLIC_API_KEY || '';
-
-    if (!resolvedApiKey || !resolvedApiKey.trim()) {
-      return NextResponse.json({ error: 'API key is required in environment variables' }, { status: 500 });
-    }
+    const { filePath, fileName, apiKey, provider, model, context } = await parseMultipartStream(req, tempDir);
 
     // Only accept .ipa, .apk, .zip files
     const ext = path.extname(fileName).toLowerCase();
@@ -492,9 +493,13 @@ export async function POST(req: NextRequest) {
     let headers: Record<string, string> = { 'Content-Type': 'application/json' };
     let payload: any = {};
 
-    const VALID_PROVIDERS = new Set(['ipaship', 'anthropic', 'openai', 'gemini', 'openrouter']);
-    if (!VALID_PROVIDERS.has(provider)) {
+    if (!isValidProvider(provider)) {
       return NextResponse.json({ error: `Invalid provider: ${provider}` }, { status: 400 });
+    }
+
+    const resolvedApiKey = resolveProviderApiKey(provider, apiKey);
+    if (!resolvedApiKey) {
+      return NextResponse.json({ error: getProviderApiKeyError(provider) }, { status: 400 });
     }
 
     // AbortController to cancel AI request if client disconnects
@@ -535,8 +540,8 @@ export async function POST(req: NextRequest) {
           { role: 'user', content: userPrompt },
         ],
       };
-    } else if (provider === 'ipaship') {
-      // ipaShip AI uses NVIDIA NIM endpoints natively
+    } else if (provider === 'ipaship' || provider === 'nvidia') {
+      // ipaShip AI and the explicit NVIDIA option both use NVIDIA NIM endpoints.
       apiUrl = 'https://integrate.api.nvidia.com/v1/chat/completions';
       headers['Authorization'] = `Bearer ${resolvedApiKey.trim()}`;
       payload = {
@@ -567,10 +572,17 @@ export async function POST(req: NextRequest) {
       method: 'POST',
       headers,
       body: JSON.stringify(payload),
+      signal: abortController.signal,
     });
 
     if (!response.ok) {
-      return NextResponse.json({ error: 'AI request failed' }, { status: response.status });
+      const errorText = await response.text().catch(() => '');
+      const detail = errorText ? `: ${errorText.slice(0, 300)}` : '';
+      return NextResponse.json({ error: `AI request failed for ${provider}${detail}` }, { status: response.status });
+    }
+
+    if (!response.body) {
+      return NextResponse.json({ error: 'AI response body missing' }, { status: 502 });
     }
 
     const stream = new ReadableStream({
@@ -579,7 +591,11 @@ export async function POST(req: NextRequest) {
         const reader = response.body!.getReader();
         const decoder = new TextDecoder();
 
-        controller.enqueue(encoder.encode(JSON.stringify({ type: 'meta', filesScanned: files.length }) + '\n'));
+        controller.enqueue(encoder.encode(JSON.stringify({
+          type: 'meta',
+          filesScanned: files.length,
+          fileNames: files.map((file) => file.path),
+        }) + '\n'));
 
         try {
           let buffer = '';
@@ -597,7 +613,7 @@ export async function POST(req: NextRequest) {
                 if (data === '[DONE]') continue;
                 try {
                   const parsed = JSON.parse(data);
-                  const textFragment = parsed.delta?.text || '';
+                  const textFragment = extractStreamText(parsed);
                   if (textFragment) {
                     controller.enqueue(encoder.encode(JSON.stringify({ type: 'content', text: textFragment }) + '\n'));
                   }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -45,9 +45,13 @@ const providerModels: Record<string, { label: string; value: string }[]> = {
     { label: 'Mixtral 8x22B', value: 'mistralai/mixtral-8x22b-instruct' },
   ],
   ipaship: [
-    { label: 'GLM 5.1', value: 'glm-5.1' },
     { label: 'ipaShip AI Core', value: 'meta/llama-3.1-405b-instruct' },
     { label: 'ipaShip AI Fast', value: 'meta/llama-3.1-70b-instruct' },
+  ],
+  nvidia: [
+    { label: 'Llama 3.1 405B Instruct', value: 'meta/llama-3.1-405b-instruct' },
+    { label: 'Llama 3.1 70B Instruct', value: 'meta/llama-3.1-70b-instruct' },
+    { label: 'Nemotron 70B Instruct', value: 'nvidia/llama-3.1-nemotron-70b-instruct' },
   ],
 };
 
@@ -61,7 +65,8 @@ const selectStyle = {
 export default function AuditPage() {
   const [file, setFile] = useState<File | null>(null);
   const [provider, setProvider] = useState('ipaship');
-  const [model, setModel] = useState('glm-5.1');
+  const [model, setModel] = useState('meta/llama-3.1-405b-instruct');
+  const [apiKey, setApiKey] = useState('');
   const [context, setContext] = useState('');
   const [phase, setPhase] = useState<AuditPhase>('idle');
   const [reportContent, setReportContent] = useState('');
@@ -268,6 +273,7 @@ export default function AuditPage() {
         formData.append('fileName', file.name);
         formData.append('provider', provider);
         formData.append('model', model);
+        formData.append('apiKey', apiKey);
         formData.append('context', context);
         response = await fetch('/api/audit', { method: 'POST', body: formData });
       } else {
@@ -277,6 +283,7 @@ export default function AuditPage() {
         formData.append('file', file);
         formData.append('provider', provider);
         formData.append('model', model);
+        formData.append('apiKey', apiKey);
         formData.append('context', context);
         response = await fetch('/api/audit', { method: 'POST', body: formData });
         setPhase('analyzing');
@@ -560,6 +567,16 @@ export default function AuditPage() {
   };
 
   const isReady = file && !isUploading && !uploadError;
+  const apiKeyPlaceholder =
+    provider === 'anthropic'
+      ? 'sk-ant-...'
+      : provider === 'openai'
+        ? 'sk-...'
+        : provider === 'gemini'
+          ? 'AIza...'
+          : provider === 'openrouter'
+            ? 'sk-or-v1-...'
+            : 'nvapi-...';
 
   return (
     <main className="min-h-[100dvh] w-full bg-background text-foreground selection:bg-primary/30 relative overflow-hidden font-sans">
@@ -847,6 +864,7 @@ export default function AuditPage() {
                           style={selectStyle}
                         >
                           <option value="ipaship">ipaShip AI</option>
+                          <option value="nvidia">NVIDIA NIM</option>
                           <option value="anthropic">Anthropic (Claude)</option>
                           <option value="openai">OpenAI (GPT)</option>
                           <option value="gemini">Google Gemini</option>
@@ -865,6 +883,24 @@ export default function AuditPage() {
                       </div>
 
                       {/* API Key */}
+                      <div className="space-y-2">
+                        <div className="flex items-center gap-2">
+                          <Key className="w-3.5 h-3.5 text-emerald-400" />
+                          <span className="text-xs font-semibold text-white">API Key <span className="text-muted-foreground font-normal">(BYOK)</span></span>
+                        </div>
+                        <input
+                          type="password"
+                          value={apiKey}
+                          onChange={(e) => setApiKey(e.target.value)}
+                          placeholder={apiKeyPlaceholder}
+                          autoComplete="off"
+                          spellCheck={false}
+                          className="w-full bg-white/5 border border-white/10 rounded-xl px-3 py-2.5 text-xs text-white placeholder:text-muted-foreground/50 focus:outline-none focus:border-emerald-400/50 focus:ring-1 focus:ring-emerald-400/40 transition-all"
+                        />
+                        <p className="text-[10px] leading-relaxed text-muted-foreground/70">
+                          Leave blank only when the matching server environment key is configured.
+                        </p>
+                      </div>
 
                       {/* Context */}
                       <div className="flex-1 flex flex-col space-y-2">
@@ -943,7 +979,7 @@ export default function AuditPage() {
                       icon: <Lock className="w-5 h-5 text-green-400" />,
                       iconBg: 'bg-green-500/10 border-green-500/20',
                       title: 'Zero Trust Security',
-                      desc: 'Your code is processed in ephemeral temp storage and deleted immediately. API keys stay in your browser, never on our servers.',
+                      desc: 'Your code is processed in ephemeral temp storage and deleted immediately. API keys are used only for the current audit request.',
                     },
                     {
                       icon: <Code2 className="w-5 h-5 text-blue-400" />,


### PR DESCRIPTION
## Summary
- add an explicit NVIDIA NIM provider and restore the BYOK API key field in the audit form
- send the submitted API key through both uploaded-file and fallback audit flows, with provider-specific server env fallbacks
- parse Anthropic, OpenAI/NVIDIA-compatible, and Gemini streaming chunks so non-Claude providers actually emit report text
- patch the Next SWC optional dependency lockfile entries so clean installs/builds stop rewriting the lockfile

## Validation
- node --experimental-strip-types --test src/app/api/audit/provider-config.test.mjs
- npx tsc --noEmit
- npm run build
- git diff --check

Fixes #85