### PR TITLE
Add Gracias AI SVG logo pack

### DIFF
--- a/logo/README.md
+++ b/logo/README.md
@@ -1,0 +1,23 @@
+# Gracias AI logo pack
+
+This directory contains an original SVG logo pack for Gracias AI.
+
+## Files
+
+- `logomark.svg` - icon-only mark for light backgrounds
+- `logomark-dark.svg` - icon-only mark for dark backgrounds
+- `wordmark.svg` - icon and wordmark for light backgrounds
+- `wordmark-dark.svg` - icon and wordmark for dark backgrounds
+
+## Concept
+
+The mark combines a rounded app tile, a trust shield, an AI node graph, and a policy check mark. The shapes are intentionally minimal so the logo stays readable at favicon, header, and social preview sizes.
+
+## Palette
+
+- Purple: `#a855f7`
+- Blue: `#3b82f6`
+- White: `#ffffff`
+- Dark background: `#0f172a`
+
+All assets are self-contained SVG files and do not depend on external images.

--- a/logo/logomark-dark.svg
+++ b/logo/logomark-dark.svg
@@ -1,0 +1,32 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="512" height="512" viewBox="0 0 512 512" role="img" aria-labelledby="title desc">
+  <title id="title">Gracias AI logomark for dark backgrounds</title>
+  <desc id="desc">Bright rounded app tile with an AI network, shield, and policy check mark.</desc>
+  <defs>
+    <linearGradient id="tileGradient" x1="84" y1="52" x2="430" y2="458" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#c084fc"/>
+      <stop offset="1" stop-color="#60a5fa"/>
+    </linearGradient>
+    <linearGradient id="checkGradient" x1="202" y1="300" x2="322" y2="222" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#a855f7"/>
+      <stop offset="1" stop-color="#2563eb"/>
+    </linearGradient>
+    <filter id="darkGlow" x="8" y="8" width="496" height="496" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+      <feDropShadow dx="0" dy="20" stdDeviation="32" flood-color="#60a5fa" flood-opacity="0.28"/>
+    </filter>
+  </defs>
+  <rect width="512" height="512" rx="120" fill="#0f172a"/>
+  <g filter="url(#darkGlow)">
+    <rect x="56" y="48" width="400" height="416" rx="104" fill="url(#tileGradient)"/>
+  </g>
+  <rect x="76" y="68" width="360" height="376" rx="88" fill="none" stroke="#ffffff" stroke-opacity="0.24" stroke-width="3"/>
+  <path d="M256 110c47 32 86 40 124 40v104c0 75-49 124-124 158-75-34-124-83-124-158V150c38 0 77-8 124-40Z" fill="#ffffff" fill-opacity="0.96"/>
+  <path d="M256 136c37 24 69 31 99 32v83c0 58-36 96-99 126-63-30-99-68-99-126v-83c30-1 62-8 99-32Z" fill="#ffffff"/>
+  <path d="M208 262h96" stroke="#c4b5fd" stroke-width="16" stroke-linecap="round"/>
+  <path d="M232 214l48 96" stroke="#93c5fd" stroke-width="16" stroke-linecap="round"/>
+  <path d="M280 214l-48 96" stroke="#93c5fd" stroke-width="16" stroke-linecap="round"/>
+  <circle cx="208" cy="262" r="21" fill="#a855f7"/>
+  <circle cx="256" cy="214" r="21" fill="#7c3aed"/>
+  <circle cx="304" cy="262" r="21" fill="#3b82f6"/>
+  <circle cx="256" cy="310" r="21" fill="#2563eb"/>
+  <path d="M218 304l32 32 62-74" fill="none" stroke="url(#checkGradient)" stroke-width="24" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/logo/logomark.svg
+++ b/logo/logomark.svg
@@ -1,0 +1,31 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="512" height="512" viewBox="0 0 512 512" role="img" aria-labelledby="title desc">
+  <title id="title">Gracias AI logomark</title>
+  <desc id="desc">Rounded app tile with an AI network, shield, and policy check mark.</desc>
+  <defs>
+    <linearGradient id="tileGradient" x1="84" y1="52" x2="430" y2="458" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#a855f7"/>
+      <stop offset="1" stop-color="#3b82f6"/>
+    </linearGradient>
+    <linearGradient id="checkGradient" x1="202" y1="300" x2="322" y2="222" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#a855f7"/>
+      <stop offset="1" stop-color="#3b82f6"/>
+    </linearGradient>
+    <filter id="softShadow" x="20" y="24" width="472" height="480" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+      <feDropShadow dx="0" dy="24" stdDeviation="28" flood-color="#172554" flood-opacity="0.18"/>
+    </filter>
+  </defs>
+  <rect width="512" height="512" rx="120" fill="#ffffff"/>
+  <g filter="url(#softShadow)">
+    <rect x="56" y="48" width="400" height="416" rx="104" fill="url(#tileGradient)"/>
+  </g>
+  <path d="M256 110c47 32 86 40 124 40v104c0 75-49 124-124 158-75-34-124-83-124-158V150c38 0 77-8 124-40Z" fill="#ffffff" fill-opacity="0.92"/>
+  <path d="M256 136c37 24 69 31 99 32v83c0 58-36 96-99 126-63-30-99-68-99-126v-83c30-1 62-8 99-32Z" fill="#ffffff"/>
+  <path d="M208 262h96" stroke="#c4b5fd" stroke-width="16" stroke-linecap="round"/>
+  <path d="M232 214l48 96" stroke="#93c5fd" stroke-width="16" stroke-linecap="round"/>
+  <path d="M280 214l-48 96" stroke="#93c5fd" stroke-width="16" stroke-linecap="round"/>
+  <circle cx="208" cy="262" r="21" fill="#a855f7"/>
+  <circle cx="256" cy="214" r="21" fill="#7c3aed"/>
+  <circle cx="304" cy="262" r="21" fill="#3b82f6"/>
+  <circle cx="256" cy="310" r="21" fill="#2563eb"/>
+  <path d="M218 304l32 32 62-74" fill="none" stroke="url(#checkGradient)" stroke-width="24" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/logo/wordmark-dark.svg
+++ b/logo/wordmark-dark.svg
@@ -1,0 +1,35 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="960" height="280" viewBox="0 0 960 280" role="img" aria-labelledby="title desc">
+  <title id="title">Gracias AI wordmark for dark backgrounds</title>
+  <desc id="desc">Gracias AI wordmark with bright app audit shield logomark on a dark field.</desc>
+  <defs>
+    <linearGradient id="tileGradient" x1="52" y1="42" x2="214" y2="234" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#c084fc"/>
+      <stop offset="1" stop-color="#60a5fa"/>
+    </linearGradient>
+    <linearGradient id="checkGradient" x1="107" y1="158" x2="164" y2="122" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#a855f7"/>
+      <stop offset="1" stop-color="#2563eb"/>
+    </linearGradient>
+    <filter id="markGlow" x="12" y="12" width="244" height="250" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+      <feDropShadow dx="0" dy="16" stdDeviation="22" flood-color="#60a5fa" flood-opacity="0.24"/>
+    </filter>
+  </defs>
+  <rect width="960" height="280" rx="44" fill="#0f172a"/>
+  <g filter="url(#markGlow)">
+    <rect x="48" y="40" width="208" height="208" rx="54" fill="url(#tileGradient)"/>
+  </g>
+  <rect x="58" y="50" width="188" height="188" rx="46" fill="none" stroke="#ffffff" stroke-opacity="0.22" stroke-width="2"/>
+  <path d="M152 72c25 17 46 21 66 21v55c0 40-26 66-66 84-40-18-66-44-66-84V93c20 0 41-4 66-21Z" fill="#ffffff" fill-opacity="0.96"/>
+  <path d="M128 144h48" stroke="#c4b5fd" stroke-width="9" stroke-linecap="round"/>
+  <path d="M140 120l24 48" stroke="#93c5fd" stroke-width="9" stroke-linecap="round"/>
+  <path d="M164 120l-24 48" stroke="#93c5fd" stroke-width="9" stroke-linecap="round"/>
+  <circle cx="128" cy="144" r="11" fill="#a855f7"/>
+  <circle cx="152" cy="120" r="11" fill="#7c3aed"/>
+  <circle cx="176" cy="144" r="11" fill="#3b82f6"/>
+  <circle cx="152" cy="168" r="11" fill="#2563eb"/>
+  <path d="M132 174l17 17 34-40" fill="none" stroke="url(#checkGradient)" stroke-width="13" stroke-linecap="round" stroke-linejoin="round"/>
+  <text x="304" y="132" fill="#ffffff" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="70" font-weight="800" letter-spacing="0">Gracias AI</text>
+  <text x="308" y="184" fill="#cbd5e1" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="30" font-weight="600" letter-spacing="0">App Store compliance auditor</text>
+  <path d="M309 208h248" stroke="#c084fc" stroke-width="8" stroke-linecap="round"/>
+  <path d="M579 208h116" stroke="#60a5fa" stroke-width="8" stroke-linecap="round"/>
+</svg>

--- a/logo/wordmark.svg
+++ b/logo/wordmark.svg
@@ -1,0 +1,34 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="960" height="280" viewBox="0 0 960 280" role="img" aria-labelledby="title desc">
+  <title id="title">Gracias AI wordmark</title>
+  <desc id="desc">Gracias AI wordmark with app audit shield logomark.</desc>
+  <defs>
+    <linearGradient id="tileGradient" x1="52" y1="42" x2="214" y2="234" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#a855f7"/>
+      <stop offset="1" stop-color="#3b82f6"/>
+    </linearGradient>
+    <linearGradient id="checkGradient" x1="107" y1="158" x2="164" y2="122" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#a855f7"/>
+      <stop offset="1" stop-color="#3b82f6"/>
+    </linearGradient>
+    <filter id="markShadow" x="16" y="18" width="236" height="244" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+      <feDropShadow dx="0" dy="16" stdDeviation="18" flood-color="#172554" flood-opacity="0.16"/>
+    </filter>
+  </defs>
+  <rect width="960" height="280" rx="44" fill="#ffffff"/>
+  <g filter="url(#markShadow)">
+    <rect x="48" y="40" width="208" height="208" rx="54" fill="url(#tileGradient)"/>
+  </g>
+  <path d="M152 72c25 17 46 21 66 21v55c0 40-26 66-66 84-40-18-66-44-66-84V93c20 0 41-4 66-21Z" fill="#ffffff" fill-opacity="0.94"/>
+  <path d="M128 144h48" stroke="#c4b5fd" stroke-width="9" stroke-linecap="round"/>
+  <path d="M140 120l24 48" stroke="#93c5fd" stroke-width="9" stroke-linecap="round"/>
+  <path d="M164 120l-24 48" stroke="#93c5fd" stroke-width="9" stroke-linecap="round"/>
+  <circle cx="128" cy="144" r="11" fill="#a855f7"/>
+  <circle cx="152" cy="120" r="11" fill="#7c3aed"/>
+  <circle cx="176" cy="144" r="11" fill="#3b82f6"/>
+  <circle cx="152" cy="168" r="11" fill="#2563eb"/>
+  <path d="M132 174l17 17 34-40" fill="none" stroke="url(#checkGradient)" stroke-width="13" stroke-linecap="round" stroke-linejoin="round"/>
+  <text x="304" y="132" fill="#111827" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="70" font-weight="800" letter-spacing="0">Gracias AI</text>
+  <text x="308" y="184" fill="#475569" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="30" font-weight="600" letter-spacing="0">App Store compliance auditor</text>
+  <path d="M309 208h248" stroke="#a855f7" stroke-width="8" stroke-linecap="round"/>
+  <path d="M579 208h116" stroke="#3b82f6" stroke-width="8" stroke-linecap="round"/>
+</svg>


### PR DESCRIPTION
Closes #2

## Summary
- Adds an original Gracias AI logo pack under `logo/`
- Includes logomark and wordmark SVG variants for light and dark backgrounds
- Uses the requested purple, blue, and white palette
- Represents AI, App Store review, security, and trust through a rounded app tile, neural nodes, shield, and policy check mark

## Files
- `logo/logomark.svg`
- `logo/logomark-dark.svg`
- `logo/wordmark.svg`
- `logo/wordmark-dark.svg`
- `logo/README.md`

## Verification
- Parsed all SVG files as valid XML with Ruby REXML
- Ran `git diff --check`
- Rendered all SVGs with macOS Quick Look thumbnails for a visual smoke check

All assets are self-contained SVG files and do not depend on external images.