### PR TITLE
Add Gracias AI logo assets

### DIFF
--- a/logo/README.md
+++ b/logo/README.md
@@ -1,0 +1,36 @@
+# Gracias AI Logo
+
+This folder contains an original SVG logo set for Gracias AI.
+
+## Files
+
+- `gracias-ai-logomark.svg` - icon-only mark for app icons, favicons, and compact placements.
+- `gracias-ai-wordmark-light.svg` - icon plus wordmark for light backgrounds.
+- `gracias-ai-wordmark-dark.svg` - icon plus wordmark for dark backgrounds.
+
+## Design Notes
+
+The mark combines a shield silhouette for trust and compliance, a rounded app tile for the iOS app-review context, a checkmark for audit readiness, and a small sparkle/node treatment for AI assistance. It uses the existing purple-to-blue brand palette:
+
+- Purple: `#A855F7`
+- Blue: `#3B82F6`
+- White: `#FFFFFF`
+
+## Preview
+
+### Logomark
+
+![Gracias AI logomark](./gracias-ai-logomark.svg)
+
+### Wordmarks
+
+<table>
+  <tr>
+    <th>Light background</th>
+    <th>Dark background</th>
+  </tr>
+  <tr>
+    <td><img src="./gracias-ai-wordmark-light.svg" alt="Gracias AI wordmark for light backgrounds" width="420"></td>
+    <td bgcolor="#0F172A"><img src="./gracias-ai-wordmark-dark.svg" alt="Gracias AI wordmark for dark backgrounds" width="420"></td>
+  </tr>
+</table>

--- a/logo/gracias-ai-logomark.svg
+++ b/logo/gracias-ai-logomark.svg
@@ -1,0 +1,37 @@
+<svg width="512" height="512" viewBox="0 0 512 512" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="title desc">
+  <title id="title">Gracias AI logomark</title>
+  <desc id="desc">A purple and blue shield containing a rounded app tile, audit checkmark, and AI sparkle.</desc>
+  <defs>
+    <linearGradient id="brandGradient" x1="104" y1="68" x2="428" y2="424" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#A855F7"/>
+      <stop offset="1" stop-color="#3B82F6"/>
+    </linearGradient>
+    <linearGradient id="markGradient" x1="174" y1="180" x2="340" y2="324" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#A855F7"/>
+      <stop offset="1" stop-color="#3B82F6"/>
+    </linearGradient>
+    <filter id="softShadow" x="40" y="32" width="432" height="456" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+      <feDropShadow dx="0" dy="22" stdDeviation="18" flood-color="#1E1B4B" flood-opacity="0.18"/>
+    </filter>
+  </defs>
+
+  <path
+    d="M256 52C319.2 79.8 374.1 88.6 424 102.4V222.6C424 322.2 362.1 402.8 256 459.7C149.9 402.8 88 322.2 88 222.6V102.4C137.9 88.6 192.8 79.8 256 52Z"
+    fill="url(#brandGradient)"
+    filter="url(#softShadow)"
+  />
+  <path
+    d="M256 88C309.2 111.4 355.4 118.8 397.5 130.4V224.3C397.5 309.8 344.1 378 256 426.7C167.9 378 114.5 309.8 114.5 224.3V130.4C156.6 118.8 202.8 111.4 256 88Z"
+    stroke="white"
+    stroke-opacity="0.34"
+    stroke-width="8"
+  />
+
+  <rect x="154" y="138" width="204" height="204" rx="52" fill="white" fill-opacity="0.96"/>
+  <path d="M204 252.5L238.8 287.3L312 206" stroke="url(#markGradient)" stroke-width="26" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="319" cy="297" r="13" fill="#3B82F6"/>
+  <circle cx="195" cy="197" r="10" fill="#A855F7"/>
+  <path d="M322 166L330.5 184.5L349 193L330.5 201.5L322 220L313.5 201.5L295 193L313.5 184.5L322 166Z" fill="url(#markGradient)"/>
+  <path d="M196 197H232" stroke="#A855F7" stroke-width="10" stroke-linecap="round" opacity="0.34"/>
+  <path d="M319 297H282" stroke="#3B82F6" stroke-width="10" stroke-linecap="round" opacity="0.34"/>
+</svg>

--- a/logo/gracias-ai-wordmark-dark.svg
+++ b/logo/gracias-ai-wordmark-dark.svg
@@ -1,0 +1,28 @@
+<svg width="960" height="260" viewBox="0 0 960 260" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="title desc">
+  <title id="title">Gracias AI wordmark for dark backgrounds</title>
+  <desc id="desc">Gracias AI wordmark with the shield logomark and white text for dark backgrounds.</desc>
+  <defs>
+    <linearGradient id="brandGradient" x1="48" y1="34" x2="216" y2="218" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#A855F7"/>
+      <stop offset="1" stop-color="#3B82F6"/>
+    </linearGradient>
+    <linearGradient id="markGradient" x1="84" y1="92" x2="170" y2="168" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#A855F7"/>
+      <stop offset="1" stop-color="#3B82F6"/>
+    </linearGradient>
+  </defs>
+
+  <g>
+    <path d="M132 28C164.3 42.2 192.2 46.7 218 53.8V114.8C218 165.7 186.3 206.8 132 235.7C77.7 206.8 46 165.7 46 114.8V53.8C71.8 46.7 99.7 42.2 132 28Z" fill="url(#brandGradient)"/>
+    <path d="M132 48C158.5 59.6 181.7 63.5 203 69.2V115.6C203 158.7 176.2 193 132 217.2C87.8 193 61 158.7 61 115.6V69.2C82.3 63.5 105.5 59.6 132 48Z" stroke="white" stroke-opacity="0.34" stroke-width="5"/>
+    <rect x="80" y="72" width="104" height="104" rx="27" fill="white" fill-opacity="0.96"/>
+    <path d="M106 130.5L124 148.5L162 106.5" stroke="url(#markGradient)" stroke-width="14" stroke-linecap="round" stroke-linejoin="round"/>
+    <circle cx="166" cy="154" r="6.5" fill="#3B82F6"/>
+    <circle cx="101" cy="102" r="5.5" fill="#A855F7"/>
+    <path d="M168 87L172.2 96.2L181.5 100.5L172.2 104.8L168 114L163.8 104.8L154.5 100.5L163.8 96.2L168 87Z" fill="url(#markGradient)"/>
+  </g>
+
+  <text x="270" y="119" fill="#FFFFFF" font-family="Inter, SF Pro Display, Segoe UI, Arial, sans-serif" font-size="62" font-weight="760">Gracias AI</text>
+  <text x="274" y="169" fill="#CBD5E1" font-family="Inter, SF Pro Text, Segoe UI, Arial, sans-serif" font-size="24" font-weight="540">App Store compliance auditor</text>
+  <rect x="273" y="191" width="152" height="6" rx="3" fill="url(#brandGradient)"/>
+</svg>

--- a/logo/gracias-ai-wordmark-light.svg
+++ b/logo/gracias-ai-wordmark-light.svg
@@ -1,0 +1,28 @@
+<svg width="960" height="260" viewBox="0 0 960 260" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="title desc">
+  <title id="title">Gracias AI wordmark for light backgrounds</title>
+  <desc id="desc">Gracias AI wordmark with the shield logomark and dark text for light backgrounds.</desc>
+  <defs>
+    <linearGradient id="brandGradient" x1="48" y1="34" x2="216" y2="218" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#A855F7"/>
+      <stop offset="1" stop-color="#3B82F6"/>
+    </linearGradient>
+    <linearGradient id="markGradient" x1="84" y1="92" x2="170" y2="168" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#A855F7"/>
+      <stop offset="1" stop-color="#3B82F6"/>
+    </linearGradient>
+  </defs>
+
+  <g>
+    <path d="M132 28C164.3 42.2 192.2 46.7 218 53.8V114.8C218 165.7 186.3 206.8 132 235.7C77.7 206.8 46 165.7 46 114.8V53.8C71.8 46.7 99.7 42.2 132 28Z" fill="url(#brandGradient)"/>
+    <path d="M132 48C158.5 59.6 181.7 63.5 203 69.2V115.6C203 158.7 176.2 193 132 217.2C87.8 193 61 158.7 61 115.6V69.2C82.3 63.5 105.5 59.6 132 48Z" stroke="white" stroke-opacity="0.34" stroke-width="5"/>
+    <rect x="80" y="72" width="104" height="104" rx="27" fill="white" fill-opacity="0.96"/>
+    <path d="M106 130.5L124 148.5L162 106.5" stroke="url(#markGradient)" stroke-width="14" stroke-linecap="round" stroke-linejoin="round"/>
+    <circle cx="166" cy="154" r="6.5" fill="#3B82F6"/>
+    <circle cx="101" cy="102" r="5.5" fill="#A855F7"/>
+    <path d="M168 87L172.2 96.2L181.5 100.5L172.2 104.8L168 114L163.8 104.8L154.5 100.5L163.8 96.2L168 87Z" fill="url(#markGradient)"/>
+  </g>
+
+  <text x="270" y="119" fill="#111827" font-family="Inter, SF Pro Display, Segoe UI, Arial, sans-serif" font-size="62" font-weight="760">Gracias AI</text>
+  <text x="274" y="169" fill="#4B5563" font-family="Inter, SF Pro Text, Segoe UI, Arial, sans-serif" font-size="24" font-weight="540">App Store compliance auditor</text>
+  <rect x="273" y="191" width="152" height="6" rx="3" fill="url(#brandGradient)"/>
+</svg>


### PR DESCRIPTION
## Summary
- Added an original SVG logomark for Gracias AI.
- Added light and dark SVG wordmark variants.
- Added a logo README with design notes and preview embeds.

## Preview

### Logomark
![Gracias AI logomark](https://raw.githubusercontent.com/s787741398/ipaship-app-reviewer/add-gracias-ai-logo/logo/gracias-ai-logomark.svg)

### Light wordmark
![Gracias AI light wordmark](https://raw.githubusercontent.com/s787741398/ipaship-app-reviewer/add-gracias-ai-logo/logo/gracias-ai-wordmark-light.svg)

### Dark wordmark
The dark wordmark uses white text on transparent background and is included for dark surfaces.

Refs #2