### PR TITLE
Add NVIDIA API key provider support

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ AI-powered iOS App Store compliance auditor. Upload your `.ipa` file and get a c
 
 - **IPA Analysis** — Upload `.ipa` files (up to 150MB) for automated compliance auditing
 - **Full Guidelines Coverage** — Checks all 6 major App Store Review Guideline categories: Safety, Performance, Business, Design, Legal & Privacy, and Technical
-- **Multi-Provider AI** — Bring your own key from Anthropic (Claude), OpenAI (GPT), Google Gemini, or OpenRouter
+- **Multi-Provider AI** — Bring your own key from Anthropic (Claude), NVIDIA, OpenAI (GPT), Google Gemini, or OpenRouter
 - **Model Selection** — Choose specific models per provider (Claude Sonnet 4, GPT-4o, Gemini 2.5 Flash, etc.)
 - **Real-Time Streaming** — Watch your audit report generate live as the AI analyzes your code
 - **Export Reports** — Download as Markdown or PDF
@@ -32,7 +32,7 @@ AI-powered iOS App Store compliance auditor. Upload your `.ipa` file and get a c
 
 - Node.js 18+
 - MongoDB URI (Atlas or local)
-- API key from at least one AI provider
+- API key from at least one AI provider: `ANTHROPIC_API_KEY`, `NVIDIA_API_KEY` or `NVIDIA_KEY`, `OPENAI_API_KEY`, `GEMINI_API_KEY`, or `OPENROUTER_API_KEY`
 - `unzip` installed on the server/runtime environment
 
 ```bash

--- a/src/app/api/audit/route.ts
+++ b/src/app/api/audit/route.ts
@@ -477,7 +477,7 @@ export async function POST(req: NextRequest) {
 
     // Stream-parse the multipart upload — writes file directly to disk
     // without ever loading the full file into memory
-    const { filePath, fileName, provider, model, context } = await parseMultipartStream(req, tempDir);
+    const { filePath, fileName, apiKey, provider, model, context } = await parseMultipartStream(req, tempDir);
 
     // Only accept .ipa, .apk, .zip files
     const ext = path.extname(fileName).toLowerCase();
@@ -511,22 +511,23 @@ export async function POST(req: NextRequest) {
     let headers: Record<string, string> = { 'Content-Type': 'application/json' };
     let payload: any = {};
 
-    const VALID_PROVIDERS = new Set(['ipaship', 'anthropic', 'openai', 'gemini', 'openrouter']);
+    const VALID_PROVIDERS = new Set(['ipaship', 'nvidia', 'anthropic', 'openai', 'gemini', 'openrouter']);
     if (!VALID_PROVIDERS.has(provider)) {
       return NextResponse.json({ error: `Invalid provider: ${provider}` }, { status: 400 });
     }
 
     const providerApiKeys: Record<string, string | undefined> = {
-      ipaship: process.env.NVIDIA_KEY || process.env.NEXT_PUBLIC_API_KEY,
+      ipaship: process.env.NVIDIA_API_KEY || process.env.NVIDIA_KEY || process.env.NEXT_PUBLIC_API_KEY,
+      nvidia: process.env.NVIDIA_API_KEY || process.env.NVIDIA_KEY || process.env.NEXT_PUBLIC_API_KEY,
       anthropic: process.env.ANTHROPIC_API_KEY,
       openai: process.env.OPENAI_API_KEY,
       gemini: process.env.GEMINI_API_KEY,
       openrouter: process.env.OPENROUTER_API_KEY,
     };
-    const resolvedApiKey = providerApiKeys[provider] || '';
+    const resolvedApiKey = apiKey || providerApiKeys[provider] || '';
 
     if (!resolvedApiKey.trim()) {
-      return NextResponse.json({ error: `API key is required for ${provider} in environment variables` }, { status: 500 });
+      return NextResponse.json({ error: `API key is required for ${provider} in the request or environment variables` }, { status: 500 });
     }
 
     // AbortController to cancel AI request if client disconnects
@@ -567,8 +568,8 @@ export async function POST(req: NextRequest) {
           { role: 'user', content: userPrompt },
         ],
       };
-    } else if (provider === 'ipaship') {
-      // ipaShip AI uses NVIDIA NIM endpoints natively
+    } else if (provider === 'ipaship' || provider === 'nvidia') {
+      // ipaShip AI and the NVIDIA provider use NVIDIA NIM endpoints natively.
       apiUrl = 'https://integrate.api.nvidia.com/v1/chat/completions';
       headers['Authorization'] = `Bearer ${resolvedApiKey.trim()}`;
       payload = {

--- a/src/app/api/github-stars/route.test.mjs
+++ b/src/app/api/github-stars/route.test.mjs
@@ -13,10 +13,12 @@ test('GitHub stars route uses an owner/repo API URL for this repository', () => 
 });
 
 test('audit route resolves API keys from the selected provider env var', () => {
-  for (const envName of ['NVIDIA_KEY', 'ANTHROPIC_API_KEY', 'OPENAI_API_KEY', 'GEMINI_API_KEY', 'OPENROUTER_API_KEY']) {
+  for (const envName of ['NVIDIA_API_KEY', 'NVIDIA_KEY', 'ANTHROPIC_API_KEY', 'OPENAI_API_KEY', 'GEMINI_API_KEY', 'OPENROUTER_API_KEY']) {
     assert.match(auditRouteSource, new RegExp(`process\\.env\\.${envName}`));
   }
 
   assert.match(auditRouteSource, /providerApiKeys\[provider\]/);
-  assert.match(auditRouteSource, /API key is required for \$\{provider\}/);
+  assert.match(auditRouteSource, /apiKey \|\| providerApiKeys\[provider\]/);
+  assert.match(auditRouteSource, /provider === 'ipaship' \|\| provider === 'nvidia'/);
+  assert.match(auditRouteSource, /API key is required for \$\{provider\} in the request or environment variables/);
 });

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -46,6 +46,10 @@ const providerModels: Record<string, { label: string; value: string }[]> = {
     { label: 'Llama 3.1 405B', value: 'meta-llama/llama-3.1-405b-instruct' },
     { label: 'Mixtral 8x22B', value: 'mistralai/mixtral-8x22b-instruct' },
   ],
+  nvidia: [
+    { label: 'Llama 3.1 405B', value: 'meta/llama-3.1-405b-instruct' },
+    { label: 'Llama 3.1 70B', value: 'meta/llama-3.1-70b-instruct' },
+  ],
   ipaship: [
     { label: 'GLM 5.1', value: 'glm-5.1' },
     { label: 'ipaShip AI Core', value: 'meta/llama-3.1-405b-instruct' },
@@ -143,6 +147,7 @@ export default function AuditPage() {
   const [file, setFile] = useState<File | null>(null);
   const [provider, setProvider] = useState('ipaship');
   const [model, setModel] = useState('glm-5.1');
+  const [aiApiKey, setAiApiKey] = useState('');
   const [context, setContext] = useState('');
   const [phase, setPhase] = useState<AuditPhase>('idle');
   const [reportContent, setReportContent] = useState('');
@@ -358,6 +363,7 @@ export default function AuditPage() {
         formData.append('fileName', file.name);
         formData.append('provider', provider);
         formData.append('model', model);
+        formData.append('apiKey', aiApiKey);
         formData.append('context', context);
         response = await fetch('/api/audit', { method: 'POST', body: formData });
       } else {
@@ -367,6 +373,7 @@ export default function AuditPage() {
         formData.append('file', file);
         formData.append('provider', provider);
         formData.append('model', model);
+        formData.append('apiKey', aiApiKey);
         formData.append('context', context);
         response = await fetch('/api/audit', { method: 'POST', body: formData });
         setPhase('analyzing');
@@ -916,6 +923,7 @@ export default function AuditPage() {
                         aria-label="AI provider"
                       >
                         <option value="ipaship">ipaShip AI</option>
+                        <option value="nvidia">NVIDIA</option>
                         <option value="anthropic">Anthropic</option>
                         <option value="openai">OpenAI</option>
                         <option value="gemini">Gemini</option>
@@ -933,6 +941,15 @@ export default function AuditPage() {
                         ))}
                       </select>
                     </div>
+                    <input
+                      value={aiApiKey}
+                      onChange={(e) => setAiApiKey(e.target.value)}
+                      type="password"
+                      placeholder={`${provider === 'nvidia' || provider === 'ipaship' ? 'NVIDIA' : provider === 'anthropic' ? 'Claude' : provider} API key (optional if configured on server)`}
+                      className="w-full rounded-lg border border-[#f4f0e8]/10 bg-[#f4f0e8]/5 px-3 py-2.5 text-xs font-medium text-[#f4f0e8] outline-none transition-colors placeholder:text-[#8b9691] hover:bg-[#f4f0e8]/[0.08] focus:ring-1 focus:ring-[#9be15d]/50"
+                      aria-label="AI API key"
+                      autoComplete="off"
+                    />
 
                     <button
                       type="button"


### PR DESCRIPTION
Closes #85.

## Changes
- Adds NVIDIA as a first-class AI provider in the UI with NVIDIA NIM model choices.
- Sends the user-provided API key from the audit form to `/api/audit` for both fresh uploads and previously uploaded files.
- Uses request-provided API keys before falling back to server environment variables.
- Supports both `NVIDIA_API_KEY` and the existing `NVIDIA_KEY` env names while preserving Anthropic/Claude, OpenAI, Gemini, OpenRouter, and ipaShip behavior.
- Updates the provider-key test and README provider docs.

## Validation
- `node --test src/app/api/github-stars/route.test.mjs src/utils/report-summary.test.mjs`
- `npm run build` with `TMP`/`TEMP` redirected to a repo-local temp directory to avoid a Windows temp socket permission issue
- `git diff --check`