### PR TITLE
Add ipaShip SVG logo pack

### DIFF
--- a/public/brand/README.md
+++ b/public/brand/README.md
@@ -1,0 +1,32 @@
+# ipaShip Logo Pack
+
+Original SVG logo assets for ipaShip, designed for the app review and compliance auditor product.
+
+## Files
+
+- `ipaship-logomark.svg` - app icon style logomark on transparent canvas
+- `ipaship-logomark-dark.svg` - dark tile variant for dark surfaces
+- `ipaship-wordmark.svg` - horizontal wordmark for light surfaces
+- `ipaship-wordmark-dark.svg` - horizontal wordmark on dark surface
+- `ipaship-logo-preview.svg` - review sheet showing the lockups in context
+
+## Concept
+
+The mark combines four product ideas:
+
+- Shield: app security and compliance review
+- Checkmark: App Store readiness and approval confidence
+- Launch trail: the "ship" in ipaShip and faster release flow
+- Nodes: AI-assisted policy analysis and issue tracing
+
+The design avoids platform trademarks while keeping an app-icon-like shape that fits the product's iOS and mobile review context.
+
+## Palette
+
+- Purple: `#a855f7`
+- Blue: `#3b82f6`
+- Green accent: `#9be15d`
+- Dark: `#050606`
+- Light: `#f4f0e8`
+
+All assets are vector SVGs and can be scaled for favicons, social images, docs, and product UI without raster artifacts.

--- a/public/brand/ipaship-logo-preview.svg
+++ b/public/brand/ipaship-logo-preview.svg
@@ -1,0 +1,45 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 960 640" role="img" aria-labelledby="title desc">
+  <title id="title">ipaShip logo preview sheet</title>
+  <desc id="desc">Preview sheet showing the ipaShip logo package on light and dark backgrounds.</desc>
+  <defs>
+    <linearGradient id="brand" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#a855f7"/>
+      <stop offset="0.48" stop-color="#3b82f6"/>
+      <stop offset="1" stop-color="#9be15d"/>
+    </linearGradient>
+    <style>
+      .label { font: 700 18px Inter, ui-sans-serif, system-ui, sans-serif; letter-spacing: 1.6px; }
+      .name { font: 900 44px Inter, ui-sans-serif, system-ui, sans-serif; letter-spacing: -1.5px; }
+      .sub { font: 800 13px Inter, ui-sans-serif, system-ui, sans-serif; letter-spacing: 2px; }
+    </style>
+  </defs>
+  <rect width="960" height="640" fill="#f7f7f2"/>
+  <rect x="48" y="54" width="864" height="238" rx="28" fill="#ffffff"/>
+  <rect x="48" y="348" width="864" height="238" rx="28" fill="#050606"/>
+  <text class="label" x="78" y="104" fill="#52605a">LIGHT BACKGROUND</text>
+  <text class="label" x="78" y="398" fill="#9aa59f">DARK BACKGROUND</text>
+  <g transform="translate(92 126) scale(.5)">
+    <rect x="16" y="16" width="224" height="224" rx="52" fill="url(#brand)"/>
+    <path d="M128 44 194 70v51c0 43-25 75-66 92-41-17-66-49-66-92V70l66-26Z" fill="#ffffff"/>
+    <path d="M87 119c21-11 49-13 82-8M92 143c24-8 49-7 77 4" fill="none" stroke="#3b82f6" stroke-width="10" stroke-linecap="round"/>
+    <circle cx="92" cy="119" r="8" fill="#050606"/><circle cx="169" cy="111" r="8" fill="#050606"/><circle cx="92" cy="143" r="8" fill="#050606"/><circle cx="169" cy="147" r="8" fill="#050606"/>
+    <path d="m105 137 18 18 37-43" fill="none" stroke="#9be15d" stroke-width="14" stroke-linecap="round" stroke-linejoin="round"/>
+  </g>
+  <text class="name" x="252" y="187" fill="#050606">ipaShip</text>
+  <text class="sub" x="254" y="219" fill="#3b82f6">APP STORE COMPLIANCE AUDITOR</text>
+  <path d="M254 238h132" stroke="#9be15d" stroke-width="4" stroke-linecap="round"/>
+  <g transform="translate(92 420) scale(.5)">
+    <rect x="16" y="16" width="224" height="224" rx="52" fill="url(#brand)"/>
+    <path d="M128 44 194 70v51c0 43-25 75-66 92-41-17-66-49-66-92V70l66-26Z" fill="#f4f0e8"/>
+    <path d="M87 119c21-11 49-13 82-8M92 143c24-8 49-7 77 4" fill="none" stroke="#3b82f6" stroke-width="10" stroke-linecap="round"/>
+    <circle cx="92" cy="119" r="8" fill="#050606"/><circle cx="169" cy="111" r="8" fill="#050606"/><circle cx="92" cy="143" r="8" fill="#050606"/><circle cx="169" cy="147" r="8" fill="#050606"/>
+    <path d="m105 137 18 18 37-43" fill="none" stroke="#9be15d" stroke-width="14" stroke-linecap="round" stroke-linejoin="round"/>
+  </g>
+  <text class="name" x="252" y="481" fill="#f4f0e8">ipaShip</text>
+  <text class="sub" x="254" y="513" fill="#9be15d">APP STORE COMPLIANCE AUDITOR</text>
+  <path d="M254 532h132" stroke="#3b82f6" stroke-width="4" stroke-linecap="round"/>
+  <text x="660" y="254" fill="#52605a" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="14">Shield = audit trust</text>
+  <text x="660" y="274" fill="#52605a" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="14">Launch trail = ship faster</text>
+  <text x="660" y="548" fill="#9aa59f" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="14">Checkmark = policy readiness</text>
+  <text x="660" y="568" fill="#9aa59f" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="14">Nodes = AI review graph</text>
+</svg>

--- a/public/brand/ipaship-logomark-dark.svg
+++ b/public/brand/ipaship-logomark-dark.svg
@@ -1,0 +1,32 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 256" role="img" aria-labelledby="title desc">
+  <title id="title">ipaShip logomark dark variant</title>
+  <desc id="desc">Dark rounded app tile containing a security shield, launch trail, and compliance check.</desc>
+  <defs>
+    <linearGradient id="tile" x1="24" y1="16" x2="224" y2="236" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#050606"/>
+      <stop offset="0.55" stop-color="#0d1b1d"/>
+      <stop offset="1" stop-color="#14251f"/>
+    </linearGradient>
+    <linearGradient id="ring" x1="28" y1="18" x2="228" y2="238" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#a855f7"/>
+      <stop offset="0.52" stop-color="#3b82f6"/>
+      <stop offset="1" stop-color="#9be15d"/>
+    </linearGradient>
+    <linearGradient id="shield" x1="70" y1="52" x2="182" y2="196" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#f4f0e8"/>
+      <stop offset="1" stop-color="#b8f3ff"/>
+    </linearGradient>
+  </defs>
+  <rect x="16" y="16" width="224" height="224" rx="52" fill="url(#tile)"/>
+  <rect x="22" y="22" width="212" height="212" rx="46" fill="none" stroke="url(#ring)" stroke-width="3"/>
+  <path d="M60 184c38-3 61-20 76-51 7-14 13-29 25-42 10-10 24-17 43-19-5 17-14 31-26 43-13 13-28 21-43 28-31 15-52 36-60 68-9-8-14-17-15-27Z" fill="#9be15d" opacity="0.12"/>
+  <path d="M128 44 194 70v51c0 43-25 75-66 92-41-17-66-49-66-92V70l66-26Z" fill="url(#shield)"/>
+  <path d="M128 61 177 80v41c0 32-18 56-49 70-31-14-49-38-49-70V80l49-19Z" fill="#050606" opacity="0.11"/>
+  <path d="M87 119c21-11 49-13 82-8" fill="none" stroke="#3b82f6" stroke-width="10" stroke-linecap="round"/>
+  <path d="M92 143c24-8 49-7 77 4" fill="none" stroke="#a855f7" stroke-width="10" stroke-linecap="round"/>
+  <circle cx="92" cy="119" r="8" fill="#050606"/>
+  <circle cx="169" cy="111" r="8" fill="#050606"/>
+  <circle cx="92" cy="143" r="8" fill="#050606"/>
+  <circle cx="169" cy="147" r="8" fill="#050606"/>
+  <path d="m105 137 18 18 37-43" fill="none" stroke="#9be15d" stroke-width="14" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/public/brand/ipaship-logomark.svg
+++ b/public/brand/ipaship-logomark.svg
@@ -1,0 +1,31 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 256" role="img" aria-labelledby="title desc">
+  <title id="title">ipaShip logomark</title>
+  <desc id="desc">Rounded app tile containing a security shield, launch trail, and compliance check.</desc>
+  <defs>
+    <linearGradient id="tile" x1="24" y1="16" x2="224" y2="236" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#a855f7"/>
+      <stop offset="0.48" stop-color="#3b82f6"/>
+      <stop offset="1" stop-color="#9be15d"/>
+    </linearGradient>
+    <linearGradient id="shield" x1="70" y1="52" x2="182" y2="196" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#ffffff"/>
+      <stop offset="1" stop-color="#dff7ff"/>
+    </linearGradient>
+    <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
+      <feDropShadow dx="0" dy="16" stdDeviation="16" flood-color="#061213" flood-opacity="0.22"/>
+    </filter>
+  </defs>
+  <rect x="16" y="16" width="224" height="224" rx="52" fill="url(#tile)"/>
+  <path d="M60 184c38-3 61-20 76-51 7-14 13-29 25-42 10-10 24-17 43-19-5 17-14 31-26 43-13 13-28 21-43 28-31 15-52 36-60 68-9-8-14-17-15-27Z" fill="#050606" opacity="0.16"/>
+  <g filter="url(#shadow)">
+    <path d="M128 44 194 70v51c0 43-25 75-66 92-41-17-66-49-66-92V70l66-26Z" fill="url(#shield)"/>
+    <path d="M128 61 177 80v41c0 32-18 56-49 70-31-14-49-38-49-70V80l49-19Z" fill="#050606" opacity="0.08"/>
+  </g>
+  <path d="M87 119c21-11 49-13 82-8" fill="none" stroke="#3b82f6" stroke-width="10" stroke-linecap="round"/>
+  <path d="M92 143c24-8 49-7 77 4" fill="none" stroke="#a855f7" stroke-width="10" stroke-linecap="round"/>
+  <circle cx="92" cy="119" r="8" fill="#050606"/>
+  <circle cx="169" cy="111" r="8" fill="#050606"/>
+  <circle cx="92" cy="143" r="8" fill="#050606"/>
+  <circle cx="169" cy="147" r="8" fill="#050606"/>
+  <path d="m105 137 18 18 37-43" fill="none" stroke="#9be15d" stroke-width="14" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/public/brand/ipaship-wordmark-dark.svg
+++ b/public/brand/ipaship-wordmark-dark.svg
@@ -1,0 +1,23 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 720 180" role="img" aria-labelledby="title desc">
+  <title id="title">ipaShip wordmark dark variant</title>
+  <desc id="desc">Dark background ipaShip logo lockup with logomark, product name, and App Store Compliance Auditor descriptor.</desc>
+  <defs>
+    <linearGradient id="tile" x1="18" y1="16" x2="150" y2="164" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#a855f7"/>
+      <stop offset="0.48" stop-color="#3b82f6"/>
+      <stop offset="1" stop-color="#9be15d"/>
+    </linearGradient>
+  </defs>
+  <rect width="720" height="180" rx="28" fill="#050606"/>
+  <rect x="24" y="24" width="132" height="132" rx="31" fill="url(#tile)"/>
+  <path d="M90 42 129 58v31c0 26-15 45-39 56-24-11-39-30-39-56V58l39-16Z" fill="#f4f0e8"/>
+  <path d="M65 88c13-7 30-8 50-5M68 103c15-5 30-4 47 3" fill="none" stroke="#3b82f6" stroke-width="6" stroke-linecap="round"/>
+  <circle cx="65" cy="88" r="5" fill="#050606"/>
+  <circle cx="115" cy="83" r="5" fill="#050606"/>
+  <circle cx="68" cy="103" r="5" fill="#050606"/>
+  <circle cx="115" cy="106" r="5" fill="#050606"/>
+  <path d="m75 99 11 11 24-27" fill="none" stroke="#9be15d" stroke-width="8" stroke-linecap="round" stroke-linejoin="round"/>
+  <text x="185" y="88" font-family="Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="58" font-weight="900" letter-spacing="-2" fill="#f4f0e8">ipaShip</text>
+  <text x="188" y="123" font-family="Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="17" font-weight="800" letter-spacing="2.6" fill="#9be15d">APP STORE COMPLIANCE AUDITOR</text>
+  <path d="M188 141h166" stroke="#3b82f6" stroke-width="4" stroke-linecap="round"/>
+</svg>

--- a/public/brand/ipaship-wordmark.svg
+++ b/public/brand/ipaship-wordmark.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 720 180" role="img" aria-labelledby="title desc">
+  <title id="title">ipaShip wordmark</title>
+  <desc id="desc">ipaShip logo lockup with logomark, product name, and App Store Compliance Auditor descriptor.</desc>
+  <defs>
+    <linearGradient id="tile" x1="18" y1="16" x2="150" y2="164" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#a855f7"/>
+      <stop offset="0.48" stop-color="#3b82f6"/>
+      <stop offset="1" stop-color="#9be15d"/>
+    </linearGradient>
+    <linearGradient id="word" x1="185" y1="54" x2="430" y2="130" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#050606"/>
+      <stop offset="1" stop-color="#17362a"/>
+    </linearGradient>
+  </defs>
+  <rect x="24" y="24" width="132" height="132" rx="31" fill="url(#tile)"/>
+  <path d="M90 42 129 58v31c0 26-15 45-39 56-24-11-39-30-39-56V58l39-16Z" fill="#ffffff"/>
+  <path d="M65 88c13-7 30-8 50-5M68 103c15-5 30-4 47 3" fill="none" stroke="#3b82f6" stroke-width="6" stroke-linecap="round"/>
+  <circle cx="65" cy="88" r="5" fill="#050606"/>
+  <circle cx="115" cy="83" r="5" fill="#050606"/>
+  <circle cx="68" cy="103" r="5" fill="#050606"/>
+  <circle cx="115" cy="106" r="5" fill="#050606"/>
+  <path d="m75 99 11 11 24-27" fill="none" stroke="#9be15d" stroke-width="8" stroke-linecap="round" stroke-linejoin="round"/>
+  <text x="185" y="88" font-family="Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="58" font-weight="900" letter-spacing="-2" fill="url(#word)">ipaShip</text>
+  <text x="188" y="123" font-family="Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="17" font-weight="800" letter-spacing="2.6" fill="#3b82f6">APP STORE COMPLIANCE AUDITOR</text>
+  <path d="M188 141h166" stroke="#9be15d" stroke-width="4" stroke-linecap="round"/>
+</svg>


### PR DESCRIPTION
Closes #2

## Summary
- adds an original vector logo package under `public/brand/`
- includes light/dark logomarks, light/dark wordmarks, a preview sheet, and usage notes
- uses shield, launch trail, AI node, and compliance check motifs for app audit/readiness while avoiding trademarked platform artwork

## Validation
- parsed all SVGs with Python `xml.etree.ElementTree`
- rendered `ipaship-logo-preview.svg` via Quick Look for visual review
- `git diff --check`

No public payment details are included.