### PR TITLE
feat: Binary compare module and CLI agent (closes #97)

### DIFF
--- a/src/lib/binary-compare/cli.js
+++ b/src/lib/binary-compare/cli.js
@@ -1,0 +1,130 @@
+#!/usr/bin/env node
+
+const { compareBinaryContents } = require("./compare");
+const { execSync } = require("child_process");
+const fs = require("fs");
+const path = require("path");
+
+function extractIPA(ipaPath, outputDir) {
+  if (!fs.existsSync(ipaPath)) {
+    console.error(`Error: File not found: ${ipaPath}`);
+    process.exit(1);
+  }
+  fs.mkdirSync(outputDir, { recursive: true });
+  try {
+    execSync(`unzip -o "${ipaPath}" -d "${outputDir}"`, { stdio: "pipe" });
+  } catch {
+    console.error(`Error: Failed to extract ${ipaPath}`);
+    process.exit(1);
+  }
+  return outputDir;
+}
+
+function collectFiles(dir, prefix = "") {
+  const files = new Map();
+  const entries = fs.readdirSync(dir, { withFileTypes: true });
+  for (const entry of entries) {
+    const fullPath = path.join(dir, entry.name);
+    const relativePath = prefix ? `${prefix}/${entry.name}` : entry.name;
+    if (entry.isDirectory()) {
+      const subFiles = collectFiles(fullPath, relativePath);
+      for (const [name, buf] of subFiles) {
+        files.set(name, buf);
+      }
+    } else {
+      try {
+        files.set(relativePath, fs.readFileSync(fullPath));
+      } catch {}
+    }
+  }
+  return files;
+}
+
+async function main() {
+  const args = process.argv.slice(2);
+
+  if (args.length < 2) {
+    console.log("Usage: ipaship-compare --file <location1> --file <location2>");
+    console.log("");
+    console.log("Compare binary contents of two IPA or app versions.");
+    console.log("Generates a JSON diff report and knowledge graph.");
+    process.exit(1);
+  }
+
+  const files: string[] = [];
+  for (let i = 0; i < args.length; i++) {
+    if (args[i] === "--file" && args[i + 1]) {
+      files.push(args[i + 1]);
+      i++;
+    }
+  }
+
+  if (files.length !== 2) {
+    console.error("Error: Exactly two files required. Use --file <path1> --file <path2>");
+    process.exit(1);
+  }
+
+  const [file1, file2] = files;
+
+  console.log(`Comparing:\n  v1: ${file1}\n  v2: ${file2}`);
+
+  const tmpDir1 = path.join(require("os").tmpdir(), `ipaship-compare-v1-${Date.now()}`);
+  const tmpDir2 = path.join(require("os").tmpdir(), `ipaship-compare-v2-${Date.now()}`);
+
+  console.log("Extracting v1...");
+  extractIPA(file1, tmpDir1);
+  console.log("Extracting v2...");
+  extractIPA(file2, tmpDir2);
+
+  const filesV1 = collectFiles(tmpDir1);
+  const filesV2 = collectFiles(tmpDir2);
+
+  console.log(`Found ${filesV1.size} files in v1, ${filesV2.size} files in v2`);
+
+  const report = compareBinaryContents(filesV1, filesV2, path.basename(file1), path.basename(file2));
+
+  console.log("\n--- Binary Compare Report ---");
+  console.log(`Total files:   ${report.totalFiles}`);
+  console.log(`Added:         ${report.addedFiles}`);
+  console.log(`Removed:       ${report.removedFiles}`);
+  console.log(`Modified:      ${report.modifiedFiles}`);
+  console.log(`Unchanged:     ${report.unchangedFiles}`);
+  console.log(`\nKnowledge graph nodes: ${report.knowledgeGraph.length}`);
+
+  if (report.diffs.filter(d => d.modified).length > 0) {
+    console.log("\n--- Modified Files (top 10 by size diff) ---");
+    report.diffs
+      .filter(d => d.modified)
+      .sort((a, b) => b.sizeDiff - a.sizeDiff)
+      .slice(0, 10)
+      .forEach(d => {
+        console.log(`  ${d.file}: ${d.sizeV1}B -> ${d.sizeV2}B (${d.sizeDiffPercent > 0 ? "+" : ""}${d.sizeDiffPercent.toFixed(1)}%)`);
+      });
+  }
+
+  if (report.diffs.filter(d => d.added).length > 0) {
+    console.log("\n--- Added Files ---");
+    report.diffs.filter(d => d.added).forEach(d => {
+      console.log(`  + ${d.file} (${d.sizeV2}B)`);
+    });
+  }
+
+  if (report.diffs.filter(d => d.removed).length > 0) {
+    console.log("\n--- Removed Files ---");
+    report.diffs.filter(d => d.removed).forEach(d => {
+      console.log(`  - ${d.file} (was ${d.sizeV1}B)`);
+    });
+  }
+
+  const outputPath = `binary-compare-report-${Date.now()}.json`;
+  fs.writeFileSync(outputPath, JSON.stringify(report, null, 2));
+  console.log(`\nFull report saved to: ${outputPath}`);
+
+  require("fs").rmSync(tmpDir1, { recursive: true, force: true });
+  require("fs").rmSync(tmpDir2, { recursive: true, force: true });
+}
+
+main().catch(err => {
+  console.error("Fatal error:", err);
+  process.exit(1);
+});

--- a/src/lib/binary-compare/compare.ts
+++ b/src/lib/binary-compare/compare.ts
@@ -1,0 +1,176 @@
+export interface BinaryDiffResult {
+  file: string;
+  sizeV1: number;
+  sizeV2: number;
+  sizeDiff: number;
+  sizeDiffPercent: number;
+  hashV1: string;
+  hashV2: string;
+  hashMatch: boolean;
+  added: boolean;
+  removed: boolean;
+  modified: boolean;
+}
+
+export interface BinaryCompareReport {
+  version1: string;
+  version2: string;
+  timestamp: string;
+  totalFiles: number;
+  addedFiles: number;
+  removedFiles: number;
+  modifiedFiles: number;
+  unchangedFiles: number;
+  diffs: BinaryDiffResult[];
+  knowledgeGraph: KnowledgeGraphNode[];
+}
+
+export interface KnowledgeGraphNode {
+  id: string;
+  label: string;
+  type: "added" | "removed" | "modified" | "unchanged" | "category";
+  metadata?: Record<string, string | number>;
+  connections: string[];
+}
+
+function crc32(data: Buffer): number {
+  let crc = 0xffffffff;
+  for (let i = 0; i < data.length; i++) {
+    crc = (crc >>> 8) ^ crc32Table[(crc ^ data[i]) & 0xff];
+  }
+  return (crc ^ 0xffffffff) >>> 0;
+}
+
+const crc32Table = (() => {
+  const table: number[] = [];
+  for (let i = 0; i < 256; i++) {
+    let c = i;
+    for (let j = 0; j < 8; j++) {
+      c = (c & 1) ? (0xedb88320 ^ (c >>> 1)) : (c >>> 1);
+    }
+    table[i] = c >>> 0;
+  }
+  return table;
+})();
+
+function hashBuffer(buf: Buffer): string {
+  const hash = crc32(buf);
+  return hash.toString(16).padStart(8, "0");
+}
+
+function categorizeFile(filename: string): string {
+  if (filename.endsWith(".dylib") || filename.endsWith(".so") || filename.endsWith(".dll")) return "shared-library";
+  if (filename.endsWith(".framework/") || filename.includes(".framework/")) return "framework";
+  if (filename.endsWith(".app/") || filename.includes(".app/")) return "app-bundle";
+  if (filename.endsWith(".nib") || filename.endsWith(".storyboardc")) return "ui-resource";
+  if (filename.endsWith(".plist")) return "configuration";
+  if (filename.endsWith(".png") || filename.endsWith(".jpg") || filename.endsWith(".pdf")) return "asset";
+  if (filename.endsWith(".strings")) return "localization";
+  if (filename.endsWith(".js") || filename.endsWith(".wasm")) return "runtime";
+  return "other";
+}
+
+export function compareBinaryContents(
+  filesV1: Map<string, Buffer>,
+  filesV2: Map<string, Buffer>,
+  version1: string,
+  version2: string
+): BinaryCompareReport {
+  const diffs: BinaryDiffResult[] = [];
+  const knowledgeGraph: KnowledgeGraphNode[] = [];
+  const allKeys = new Set([...filesV1.keys(), ...filesV2.keys()]);
+
+  let addedFiles = 0;
+  let removedFiles = 0;
+  let modifiedFiles = 0;
+  let unchangedFiles = 0;
+
+  const categoryNodes = new Map<string, string>();
+
+  for (const file of allKeys) {
+    const v1 = filesV1.get(file);
+    const v2 = filesV2.get(file);
+    const category = categorizeFile(file);
+
+    if (!categoryNodes.has(category)) {
+      const nodeId = `cat-${category}`;
+      categoryNodes.set(category, nodeId);
+      knowledgeGraph.push({ id: nodeId, label: category, type: "category", connections: [] });
+    }
+
+    const result: BinaryDiffResult = {
+      file,
+      sizeV1: v1?.byteLength ?? 0,
+      sizeV2: v2?.byteLength ?? 0,
+      sizeDiff: 0,
+      sizeDiffPercent: 0,
+      hashV1: v1 ? hashBuffer(v1) : "",
+      hashV2: v2 ? hashBuffer(v2) : "",
+      hashMatch: false,
+      added: false,
+      removed: false,
+      modified: false,
+    };
+
+    if (v1 && !v2) {
+      result.removed = true;
+      removedFiles++;
+    } else if (!v1 && v2) {
+      result.added = true;
+      addedFiles++;
+    } else if (v1 && v2) {
+      result.sizeDiff = Math.abs(v2.byteLength - v1.byteLength);
+      result.sizeDiffPercent = v1.byteLength > 0 ? (result.sizeDiff / v1.byteLength) * 100 : 0;
+      result.hashMatch = result.hashV1 === result.hashV2;
+      if (result.hashMatch) {
+        unchangedFiles++;
+        result.modified = false;
+      } else {
+        modifiedFiles++;
+        result.modified = true;
+      }
+    }
+
+    diffs.push(result);
+
+    const nodeId = `file-${file.replace(/[^a-zA-Z0-9]/g, "_")}`;
+    knowledgeGraph.push({
+      id: nodeId,
+      label: file.split("/").pop() || file,
+      type: result.added ? "added" : result.removed ? "removed" : result.modified ? "modified" : "unchanged",
+      metadata: {
+        sizeV1: result.sizeV1,
+        sizeV2: result.sizeV2,
+        sizeDiff: result.sizeDiff,
+        sizeDiffPercent: Math.round(result.sizeDiffPercent * 100) / 100,
+        category,
+      },
+      connections: [categoryNodes.get(category)!],
+    });
+
+    const catNode = knowledgeGraph.find(n => n.id === categoryNodes.get(category));
+    if (catNode && !catNode.connections.includes(nodeId)) {
+      catNode.connections.push(nodeId);
+    }
+  }
+
+  diffs.sort((a, b) => {
+    if (a.added !== b.added) return a.added ? 1 : -1;
+    if (a.removed !== b.removed) return a.removed ? -1 : 1;
+    if (a.modified !== b.modified) return a.modified ? -1 : 1;
+    return b.sizeDiff - a.sizeDiff;
+  });
+
+  return {
+    version1,
+    version2,
+    timestamp: new Date().toISOString(),
+    totalFiles: allKeys.size,
+    addedFiles,
+    removedFiles,
+    modifiedFiles,
+    unchangedFiles,
+    diffs,
+    knowledgeGraph,
+  };
+}

--- a/src/lib/binary-compare/index.ts
+++ b/src/lib/binary-compare/index.ts
@@ -1,0 +1,3 @@
+import { BinaryDiffResult, BinaryCompareReport, KnowledgeGraphNode, compareBinaryContents } from "./compare";
+
+export { BinaryDiffResult, BinaryCompareReport, KnowledgeGraphNode, compareBinaryContents };


### PR DESCRIPTION
## Issue #97 — Beyond compare like Binary Compare module and CLI agent

### Implementation

**Binary Compare Module** (`src/lib/binary-compare/`)
- `compare.ts` — Core module comparing binary contents of two app versions
  - CRC32 hashing for fast binary diff detection
  - Size diff calculation with percentage change
  - Category classification: shared-library, framework, app-bundle, ui-resource, configuration, asset, localization, runtime, other
  - Knowledge graph generation with nodes and connections
  - Flags files as added/removed/modified/unchanged
  - `BinaryCompareReport` type with full stats

**CLI Agent** (`src/lib/binary-compare/cli.js`)
- Usage: `ipaship-compare --file <v1.ipa> --file <v2.ipa>`
- Auto-extracts IPA files using unzip
- Outputs full JSON report to `binary-compare-report-<timestamp>.json`
- Console summary with top modified, added, and removed files
- Cleans up temp directories after analysis

### Example Usage

```bash
npm run compare -- --file app-v1.ipa --file app-v2.ipa
```

### Report Output

```json
{
  "version1": "app-v1.ipa",
  "version2": "app-v2.ipa",
  "totalFiles": 342,
  "addedFiles": 12,
  "removedFiles": 3,
  "modifiedFiles": 28,
  "unchangedFiles": 299,
  "diffs": [...],
  "knowledgeGraph": [...]
}
```

Closes #97