### PR TITLE
Add Gracias AI logo assets

### DIFF
--- a/logo/README.md
+++ b/logo/README.md
@@ -1,0 +1,20 @@
+# Gracias AI Logo Proposal
+
+This submission adds an original vector identity for Gracias AI that keeps the current purple-to-blue palette while making the mark more specific to the product: AI-powered App Store compliance auditing.
+
+## Assets
+
+| Asset | Preview | Use |
+| --- | --- | --- |
+| `gracias-ai-logomark.svg` | <img src="./gracias-ai-logomark.svg" width="120" alt="Gracias AI logomark" /> | App icon, favicon, social avatar, compact UI |
+| `gracias-ai-wordmark-light.svg` | <img src="./gracias-ai-wordmark-light.svg" width="360" alt="Gracias AI wordmark for light backgrounds" /> | Light backgrounds |
+| `gracias-ai-wordmark-dark.svg` | <img src="./gracias-ai-wordmark-dark.svg" width="360" alt="Gracias AI wordmark for dark backgrounds" /> | Dark backgrounds |
+
+## Design Notes
+
+- The rounded square preserves an iOS-style app icon silhouette.
+- The shield communicates security, trust, and compliance.
+- The check mark represents review readiness and policy pass/fail auditing.
+- The small connected nodes add a subtle AI signal without making the mark visually busy.
+- The wordmark includes a dark-background and light-background variant so the logo remains legible across the product, docs, and social surfaces.
+

--- a/logo/gracias-ai-logomark.svg
+++ b/logo/gracias-ai-logomark.svg
@@ -1,0 +1,36 @@
+<svg width="512" height="512" viewBox="0 0 512 512" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="title desc">
+  <title id="title">Gracias AI logomark</title>
+  <desc id="desc">A rounded app icon with a gradient shield, compliance check, and AI network nodes.</desc>
+  <defs>
+    <linearGradient id="gracias-icon-bg" x1="96" y1="72" x2="416" y2="440" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#a855f7"/>
+      <stop offset="1" stop-color="#3b82f6"/>
+    </linearGradient>
+    <linearGradient id="gracias-shield" x1="166" y1="126" x2="344" y2="374" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#ffffff"/>
+      <stop offset="1" stop-color="#eef4ff"/>
+    </linearGradient>
+    <filter id="gracias-shadow" x="84" y="72" width="344" height="376" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+      <feFlood flood-opacity="0" result="BackgroundImageFix"/>
+      <feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+      <feOffset dy="18"/>
+      <feGaussianBlur stdDeviation="22"/>
+      <feComposite in2="hardAlpha" operator="out"/>
+      <feColorMatrix type="matrix" values="0 0 0 0 0.129 0 0 0 0 0.145 0 0 0 0 0.325 0 0 0 0.28 0"/>
+      <feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow_1_1"/>
+      <feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow_1_1" result="shape"/>
+    </filter>
+  </defs>
+  <rect x="56" y="56" width="400" height="400" rx="108" fill="url(#gracias-icon-bg)"/>
+  <path d="M139 155C185 150 224 133 256 112C288 133 327 150 373 155V244C373 319 325 376 256 404C187 376 139 319 139 244V155Z" fill="url(#gracias-shield)" filter="url(#gracias-shadow)"/>
+  <path d="M202 259L239 296L316 207" stroke="#3b82f6" stroke-width="32" stroke-linecap="round" stroke-linejoin="round"/>
+  <path d="M183 188L220 214M329 188L292 214M181 324L222 300M331 324L290 300" stroke="#a855f7" stroke-width="12" stroke-linecap="round" opacity="0.52"/>
+  <circle cx="180" cy="187" r="17" fill="#ffffff"/>
+  <circle cx="332" cy="187" r="17" fill="#ffffff"/>
+  <circle cx="180" cy="324" r="17" fill="#ffffff"/>
+  <circle cx="332" cy="324" r="17" fill="#ffffff"/>
+  <circle cx="180" cy="187" r="8" fill="#a855f7"/>
+  <circle cx="332" cy="187" r="8" fill="#3b82f6"/>
+  <circle cx="180" cy="324" r="8" fill="#3b82f6"/>
+  <circle cx="332" cy="324" r="8" fill="#a855f7"/>
+</svg>

--- a/logo/gracias-ai-wordmark-dark.svg
+++ b/logo/gracias-ai-wordmark-dark.svg
@@ -1,0 +1,29 @@
+<svg width="880" height="240" viewBox="0 0 880 240" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="title desc">
+  <title id="title">Gracias AI wordmark for dark backgrounds</title>
+  <desc id="desc">Gracias AI wordmark with gradient compliance shield icon and light text.</desc>
+  <defs>
+    <linearGradient id="wordmark-icon-bg-dark" x1="38" y1="30" x2="202" y2="210" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#a855f7"/>
+      <stop offset="1" stop-color="#3b82f6"/>
+    </linearGradient>
+    <linearGradient id="wordmark-ai-dark" x1="538" y1="76" x2="692" y2="76" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#c084fc"/>
+      <stop offset="1" stop-color="#60a5fa"/>
+    </linearGradient>
+  </defs>
+  <rect x="24" y="24" width="192" height="192" rx="52" fill="url(#wordmark-icon-bg-dark)"/>
+  <path d="M67 72C89 69 108 61 120 52C132 61 151 69 173 72V116C173 154 151 183 120 197C89 183 67 154 67 116V72Z" fill="#ffffff"/>
+  <path d="M94 123L112 141L148 99" stroke="#3b82f6" stroke-width="15" stroke-linecap="round" stroke-linejoin="round"/>
+  <path d="M88 88L105 101M152 88L135 101M88 158L107 146M152 158L133 146" stroke="#a855f7" stroke-width="6" stroke-linecap="round" opacity="0.58"/>
+  <circle cx="87" cy="88" r="8" fill="#ffffff"/>
+  <circle cx="153" cy="88" r="8" fill="#ffffff"/>
+  <circle cx="87" cy="158" r="8" fill="#ffffff"/>
+  <circle cx="153" cy="158" r="8" fill="#ffffff"/>
+  <circle cx="87" cy="88" r="4" fill="#a855f7"/>
+  <circle cx="153" cy="88" r="4" fill="#3b82f6"/>
+  <circle cx="87" cy="158" r="4" fill="#3b82f6"/>
+  <circle cx="153" cy="158" r="4" fill="#a855f7"/>
+  <text x="252" y="142" fill="#ffffff" font-family="Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="82" font-weight="760">Gracias</text>
+  <text x="572" y="142" fill="url(#wordmark-ai-dark)" font-family="Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="82" font-weight="820">AI</text>
+  <text x="256" y="181" fill="#d0d5dd" font-family="Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="23" font-weight="520">App Store compliance, audited with intelligence</text>
+</svg>

--- a/logo/gracias-ai-wordmark-light.svg
+++ b/logo/gracias-ai-wordmark-light.svg
@@ -1,0 +1,29 @@
+<svg width="880" height="240" viewBox="0 0 880 240" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="title desc">
+  <title id="title">Gracias AI wordmark for light backgrounds</title>
+  <desc id="desc">Gracias AI wordmark with gradient compliance shield icon and dark text.</desc>
+  <defs>
+    <linearGradient id="wordmark-icon-bg-light" x1="38" y1="30" x2="202" y2="210" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#a855f7"/>
+      <stop offset="1" stop-color="#3b82f6"/>
+    </linearGradient>
+    <linearGradient id="wordmark-ai-light" x1="538" y1="76" x2="692" y2="76" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#a855f7"/>
+      <stop offset="1" stop-color="#3b82f6"/>
+    </linearGradient>
+  </defs>
+  <rect x="24" y="24" width="192" height="192" rx="52" fill="url(#wordmark-icon-bg-light)"/>
+  <path d="M67 72C89 69 108 61 120 52C132 61 151 69 173 72V116C173 154 151 183 120 197C89 183 67 154 67 116V72Z" fill="#ffffff"/>
+  <path d="M94 123L112 141L148 99" stroke="#3b82f6" stroke-width="15" stroke-linecap="round" stroke-linejoin="round"/>
+  <path d="M88 88L105 101M152 88L135 101M88 158L107 146M152 158L133 146" stroke="#a855f7" stroke-width="6" stroke-linecap="round" opacity="0.58"/>
+  <circle cx="87" cy="88" r="8" fill="#ffffff"/>
+  <circle cx="153" cy="88" r="8" fill="#ffffff"/>
+  <circle cx="87" cy="158" r="8" fill="#ffffff"/>
+  <circle cx="153" cy="158" r="8" fill="#ffffff"/>
+  <circle cx="87" cy="88" r="4" fill="#a855f7"/>
+  <circle cx="153" cy="88" r="4" fill="#3b82f6"/>
+  <circle cx="87" cy="158" r="4" fill="#3b82f6"/>
+  <circle cx="153" cy="158" r="4" fill="#a855f7"/>
+  <text x="252" y="142" fill="#101828" font-family="Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="82" font-weight="760">Gracias</text>
+  <text x="572" y="142" fill="url(#wordmark-ai-light)" font-family="Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="82" font-weight="820">AI</text>
+  <text x="256" y="181" fill="#475467" font-family="Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="23" font-weight="520">App Store compliance, audited with intelligence</text>
+</svg>


### PR DESCRIPTION
## Summary

Adds an original Gracias AI logo set for issue #2:

- `logo/gracias-ai-logomark.svg`
- `logo/gracias-ai-wordmark-light.svg`
- `logo/gracias-ai-wordmark-dark.svg`
- `logo/README.md` with GitHub-rendered previews and design notes

## Design Rationale

The mark combines a rounded iOS-style app icon, a trust/compliance shield, a review-ready check mark, and subtle AI network nodes. It keeps the requested purple `#a855f7` and blue `#3b82f6` palette, while adding a more specific identity for AI-powered App Store compliance auditing.

## Verification

- SVG files are original vector artwork.
- XML parsing passes for all three SVG files.
- Includes both logomark and wordmark variants.
- Includes light-background and dark-background wordmark options.

Closes #2
